### PR TITLE
Update PyYAML dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "PyYAML==6.0.2",
+    "PyYAML>=6.0.2",
     "joblib>=1.4.2",
     "matplotlib>=3.1.3",
     "numpy>=1.18.1",


### PR DESCRIPTION
At the moment the patientflow package seems incompatible with the ipykernel package, when installed in the same conda environment (which is useful for using the interactive window in VSCode). Gemini has suggested that its this version constraint that is the issue. Would it be ok to relax this constraint or is it constrained for a reason? (Its not essential as the code can still be run in the terminal, but its very useful to be able to run interactively to understand whats going on).

https://github.com/copilot/share/c07a003e-43e0-8ce4-9900-9608a0bb20ff