### PR TITLE
add --skip-existing for TestPyPI upload re-runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TESTPYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TESTPYPI_PASSWORD }}
         run: |
-          twine upload --repository testpypi dist/*
+          twine upload --repository testpypi --skip-existing dist/*
 
       # Updated verification step with basic import test instead of pytest
       - name: Verify package from TestPyPI


### PR DESCRIPTION
Release workflow fails if approval (which confirms release after test push to TestPyPI) times out. This modifies workflow to skip existing release number on TestPyPI. 