### PR TITLE
Weekday-aware arrival rates by default

### DIFF
--- a/src/patientflow/predictors/incoming_admission_predictors.py
+++ b/src/patientflow/predictors/incoming_admission_predictors.py
@@ -58,12 +58,21 @@ i.e. which key(s) appear in ``weights``, matching the names given in ``filters``
 when the model was fitted with filters. If ``weights`` has only one key,
 ``filter_keys`` / ``filter_key`` may be omitted.
 
-Optional ``prediction_date`` (a :class:`~datetime.date`) anchors the calendar day
-when the model was fit with ``stratify_by_weekday=True``. Each prediction slice
-then uses the arrival rate for that slice's **actual** weekday and time-of-day
-(``datetime.weekday()``: Monday = 0, …, Sunday = 6). If ``prediction_date`` is
-omitted, behaviour matches the legacy pooled 24-hour profile
-(``arrival_rates_dict``) only.
+Optional ``prediction_date`` (a :class:`~datetime.date`) anchors the calendar
+day. The library fits weekday profiles by default, but the predict-time
+warning behaviour depends on whether ``stratify_by_weekday`` was explicitly
+opted into at fit time:
+
+- Default fit (``stratify_by_weekday=None``): weekday profiles are stored,
+  but omitting ``prediction_date`` is silent — predictions match the legacy
+  pooled 24-hour profile (``arrival_rates_dict``) and no warning fires.
+- Explicit opt-in (``stratify_by_weekday=True``): each slice uses the rate
+  for its actual weekday and time-of-day when ``prediction_date`` is passed
+  (``datetime.weekday()``: Monday = 0, …, Sunday = 6). Omitting
+  ``prediction_date`` emits a ``UserWarning`` and falls back to pooled rates
+  so existing predictions remain numerically unchanged.
+- ``strict_prediction_date=True`` at predict time turns any pooled fallback
+  into a ``ValueError`` regardless of how ``stratify_by_weekday`` was set.
 
 The deprecated nested ``prediction_context`` dict (keyword or first positional
 argument) is still accepted and emits ``DeprecationWarning``. It may include
@@ -97,6 +106,7 @@ with probability θ_t reduces the effective rate from λ_t to λ_t θ_t.
 """
 
 import warnings
+from collections import OrderedDict
 from datetime import date, datetime, timedelta, time as dt_time
 from abc import ABC, abstractmethod
 
@@ -278,6 +288,17 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
     For ``predict`` / ``predict_mean`` arguments (``prediction_time``,
     ``filter_keys`` / ``filter_key``, legacy ``prediction_context``), see the
     module docstring section *Prediction API*.
+
+    Diagnostic attributes
+    ---------------------
+    empty_filter_count : int
+        Populated during ``fit()``. Equals the number of configured filters
+        whose subset of ``train_df`` was empty. When no filters are configured,
+        equals ``1`` if ``train_df`` itself is empty and ``0`` otherwise. Reset
+        to ``0`` at the start of every ``fit()`` call. Useful for surfacing
+        configuration mismatches (e.g. a typoed service name or a service
+        that did not operate during the training window) that would otherwise
+        be hidden by the silent zero-rate fallback in ``_calculate_parameters``.
     """
 
     def __init__(self, filters=None, verbose=False, use_generating_functions=True):
@@ -293,6 +314,7 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
                 stacklevel=2,
             )
         self.metrics = {}  # Add metrics dictionary to store metadata
+        self.empty_filter_count = 0
 
         if verbose:
             # Configure logging for Jupyter notebook compatibility
@@ -683,17 +705,6 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
         prediction_date: Optional[date] = None,
         strict_prediction_date: bool = False,
     ):
-        """Yield ``(filter_key, resolved_prediction_time, arrival_rates_np)``.
-
-        Slices ``Ntimes`` intervals starting at ``snapped_prediction_time`` (on an
-        interval boundary). When ``prediction_date`` is set and weights contain
-        ``arrival_rates_by_weekday`` (from ``fit(..., stratify_by_weekday=True)``),
-        each slice uses the rate for that slice's calendar weekday and time-of-day.
-        If ``prediction_date`` is set but weekday profiles are missing, behaviour
-        depends on ``strict_prediction_date``:
-        - ``False`` (default): fall back to pooled ``arrival_rates_dict`` and warn.
-        - ``True``: raise ``ValueError``.
-        """
         Ntimes = int(prediction_window / self.yta_time_interval)
         hr, mn = snapped_prediction_time
         for filter_key in filter_keys:
@@ -720,6 +731,21 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
                     UserWarning,
                     stacklevel=4,
                 )
+            elif prediction_date is None and by_weekday is not None:
+                message = (
+                    "predictor was fit with stratify_by_weekday=True but no "
+                    f"prediction_date was supplied for filter '{filter_key}'. "
+                    "Pass prediction_date= to predict() / predict_mean() to "
+                    "use the matching weekday profile; otherwise pooled "
+                    "arrival_rates_dict is used."
+                )
+                if strict_prediction_date:
+                    raise ValueError(message)
+                # Only warn for callers who explicitly opted in at fit time.
+                # The library default also stores weekday profiles, but legacy
+                # callers who didn't request stratification stay silent.
+                if getattr(self, "_user_opted_in_to_weekday", False):
+                    warnings.warn(message, UserWarning, stacklevel=4)
 
             try:
                 if use_weekday:
@@ -830,38 +856,37 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
             raise ValueError("Could not infer a positive num_days from the index.")
         return inferred
 
+    def _empty_arrival_rates_dict(self, yta_time_interval: timedelta) -> OrderedDict:
+        rates: OrderedDict = OrderedDict()
+        _start = datetime(1970, 1, 1, 0, 0, 0, 0)
+        _stop = _start + timedelta(days=1)
+        while _start != _stop:
+            rates[_start.time()] = 0.0
+            _start = _start + yta_time_interval
+        return rates
+
     def _calculate_parameters(
         self,
         df,
         yta_time_interval: timedelta,
         num_days: Optional[int],
-        stratify_by_weekday: bool = False,
+        stratify_by_weekday: bool = True,
     ):
-        """Calculate the full 24-hour arrival-rate dictionary for the given data.
+        if len(df.index) == 0:
+            zero_rates = self._empty_arrival_rates_dict(yta_time_interval)
+            out: Dict = {"arrival_rates_dict": zero_rates}
+            if stratify_by_weekday:
+                out["arrival_rates_by_weekday"] = {
+                    d: self._empty_arrival_rates_dict(yta_time_interval)
+                    for d in range(7)
+                }
+            return out
 
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            The data frame to process.
-        yta_time_interval : timedelta
-            The granularity of arrival-rate buckets.
-        num_days : int or None
-            Divisor for pooled rates; if ``None``, inferred from ``df``'s index span.
-        stratify_by_weekday : bool, default=False
-            If True, also compute ``arrival_rates_by_weekday`` (keys ``0..6``,
-            Monday=0) for use when ``prediction_date`` is passed at predict time.
-
-        Returns
-        -------
-        dict
-            Always contains ``arrival_rates_dict``. When ``stratify_by_weekday``,
-            also ``arrival_rates_by_weekday``: ``dict[int, OrderedDict[time, float]]``.
-        """
         effective_days = self._resolve_num_days(df, num_days)
         arrival_rates_dict = time_varying_arrival_rates(
             df, yta_time_interval, effective_days, verbose=self.verbose
         )
-        out: Dict = {"arrival_rates_dict": arrival_rates_dict}
+        out = {"arrival_rates_dict": arrival_rates_dict}
         if stratify_by_weekday:
             out["arrival_rates_by_weekday"] = time_varying_arrival_rates_by_weekday(
                 df, yta_time_interval, num_days, verbose=self.verbose
@@ -877,7 +902,7 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
         num_days: Optional[int] = None,
         epsilon: float = 10**-7,
         y: Optional[None] = None,
-        stratify_by_weekday: bool = False,
+        stratify_by_weekday: Optional[bool] = None,
     ) -> "IncomingAdmissionPredictor":
         """Fit the model to the training data.
 
@@ -916,11 +941,27 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
             of the maximum value of the random variable representing number of beds.
         y : None, optional
             Ignored, present for compatibility with scikit-learn's fit method.
-        stratify_by_weekday : bool, default=False
-            If True, fit an additional per-weekday arrival profile (``Monday=0`` …
-            ``Sunday=6``). Pass ``prediction_date`` at predict time to slice the
-            window using that profile; omit ``prediction_date`` to keep using the
-            pooled 24-hour profile only.
+        stratify_by_weekday : bool or None, default=None
+            Controls whether per-weekday arrival profiles (``Monday=0`` …
+            ``Sunday=6``) are fitted alongside the pooled profile.
+
+            - ``None`` (default): weekday profiles are fitted (effective value
+              ``True``), but the predictor treats this as the *library-side*
+              default rather than an explicit opt-in. ``predict()`` calls
+              without ``prediction_date`` are silent — predictions match prior
+              numeric behaviour and legacy callers see no new warnings.
+            - ``True``: explicit opt-in to weekday stratification. The
+              **weekday contract** activates: callers should pass
+              ``prediction_date`` to ``predict()`` / ``predict_mean()`` so each
+              slice uses the matching weekday rate. Omitting ``prediction_date``
+              emits a ``UserWarning`` (and ``strict_prediction_date=True`` at
+              predict time turns the warning into a ``ValueError``).
+            - ``False``: opt out. Only the pooled 24-hour profile is stored
+              and ``arrival_rates_by_weekday`` is absent from ``weights``.
+
+            Most callers should leave this on the default. Pass ``True``
+            explicitly only when you intend to thread ``prediction_date`` at
+            predict time and want pooled-fallbacks to be surfaced loudly.
 
         Returns
         -------
@@ -977,11 +1018,21 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
                 stacklevel=2,
             )
 
+        # Resolve the sentinel default for stratify_by_weekday and track whether
+        # the user explicitly opted in. The flag gates the predict-time
+        # "missing prediction_date" warning so that legacy callers who never
+        # asked for weekday stratification don't see noise (Option 1 of the
+        # weekday-contract design).
+        user_opted_in_to_weekday = stratify_by_weekday is True
+        if stratify_by_weekday is None:
+            stratify_by_weekday = True
+
         # Store required metadata
         self.yta_time_interval = yta_time_interval
         self.yta_time_interval_hours = yta_time_interval.total_seconds() / 3600
         self.epsilon = epsilon
         self.stratify_by_weekday = stratify_by_weekday
+        self._user_opted_in_to_weekday = user_opted_in_to_weekday
 
         # Store deprecated fit-time values as predict-time fall-backs
         self._deprecated_fit_prediction_window = prediction_window
@@ -1014,12 +1065,22 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
             else None
         )
 
-        # Initialise weights with the full 24-hour arrival-rate dictionary
+        # Initialise weights with the full 24-hour arrival-rate dictionary.
+        # ``empty_filter_count`` is reset here so repeated fits don't accumulate
+        # stale counts; it is incremented for every configured filter whose
+        # subset of ``train_df`` is empty. Empty subsets still produce
+        # zero-rate weights via ``_calculate_parameters`` so downstream
+        # ``predict()`` calls remain valid; callers can inspect the counter
+        # after fit to surface configuration mismatches.
         self.weights = {}
+        self.empty_filter_count = 0
         if self.filters:
             for spec, filters in self.filters.items():
+                filtered_df = self.filter_dataframe(train_df, filters)
+                if len(filtered_df.index) == 0:
+                    self.empty_filter_count += 1
                 self.weights[spec] = self._calculate_parameters(
-                    self.filter_dataframe(train_df, filters),
+                    filtered_df,
                     yta_time_interval,
                     num_days,
                     stratify_by_weekday=stratify_by_weekday,
@@ -1132,13 +1193,21 @@ class IncomingAdmissionPredictor(BaseEstimator, TransformerMixin, ABC):
             Deprecated. Former nested dict mapping filter key to
             ``{"prediction_time": ...}``. Must contain exactly one filter key.
         prediction_date : datetime.date, optional
-            Calendar date at the snapped ``prediction_time``. When the model was fit
-            with ``stratify_by_weekday=True``, selects per-slice weekday arrival rates;
-            otherwise ignored for λ (pooled profile is used).
+            Calendar date at the snapped ``prediction_time``. When supplied,
+            selects per-slice weekday arrival rates (crossing correctly into
+            the next weekday for windows that straddle midnight). When the
+            predictor was fit with ``stratify_by_weekday=True`` *explicitly*
+            and ``prediction_date`` is omitted, a ``UserWarning`` is emitted
+            and the pooled profile is used; under the library default
+            (``stratify_by_weekday=None``) the fallback is silent so legacy
+            callers remain quiet. See
+            ``patientflow.aggregate.get_prob_dist_by_service`` for the
+            service-level helper that threads ``prediction_date`` automatically
+            per snapshot date.
         strict_prediction_date : bool, default=False
-            If ``True``, raise an error when ``prediction_date`` is provided but
-            weekday-stratified arrival rates are unavailable for the selected key.
-            If ``False``, warn and fall back to pooled arrival rates.
+            If ``True``, raise ``ValueError`` whenever any pooled-rate fallback
+            would occur — regardless of whether ``stratify_by_weekday`` was
+            opted into at fit time.
         **kwargs
             Passed to ``_get_admission_probabilities`` (e.g. ``x1``, ``y1``, …).
 
@@ -1243,12 +1312,18 @@ class DirectAdmissionPredictor(IncomingAdmissionPredictor):
         prediction_context : dict, optional
             Deprecated nested dict API.
         prediction_date : datetime.date, optional
-            Calendar anchor for weekday-stratified arrival rates when fitted with
-            ``stratify_by_weekday=True``. Otherwise λ uses the pooled profile only.
+            Calendar anchor for weekday-stratified arrival rates. Pass it to
+            use the matching weekday profile for each prediction slice; the
+            window crosses correctly into the next weekday after midnight.
+            When the predictor was fit with explicit
+            ``stratify_by_weekday=True`` and ``prediction_date`` is omitted, a
+            ``UserWarning`` is emitted; under the library default the fallback
+            is silent. See ``patientflow.aggregate.get_prob_dist_by_service``
+            for the service-level helper that supplies ``prediction_date``
+            automatically per snapshot date.
         strict_prediction_date : bool, default=False
-            If ``True``, raise an error when ``prediction_date`` is provided but
-            weekday-stratified arrival rates are unavailable for a selected key.
-            If ``False``, warn and fall back to pooled arrival rates.
+            If ``True``, raise ``ValueError`` whenever a pooled-rate fallback
+            would occur — independent of fit-time opt-in.
         **kwargs
             ``max_value`` : int, optional — maximum PMF support.
 
@@ -1407,12 +1482,16 @@ class ParametricIncomingAdmissionPredictor(IncomingAdmissionPredictor):
         prediction_context : dict, optional
             Deprecated nested dict API.
         prediction_date : datetime.date, optional
-            Calendar anchor for weekday-stratified λ when fitted with
-            ``stratify_by_weekday=True``.
+            Calendar anchor for weekday-stratified λ. Under the library
+            default the pooled fallback is silent when ``prediction_date`` is
+            omitted; explicit ``stratify_by_weekday=True`` at fit time turns
+            that fallback into a ``UserWarning``. See
+            ``patientflow.aggregate.get_prob_dist_by_service`` for the
+            service-level helper that supplies ``prediction_date``
+            automatically per snapshot date.
         strict_prediction_date : bool, default=False
-            If ``True``, raise an error when ``prediction_date`` is provided but
-            weekday-stratified arrival rates are unavailable for a selected key.
-            If ``False``, warn and fall back to pooled arrival rates.
+            If ``True``, raise ``ValueError`` whenever a pooled-rate fallback
+            would occur — independent of fit-time opt-in.
         **kwargs
             ``x1``, ``y1``, ``x2``, ``y2`` (required); optional ``max_value``.
 
@@ -1580,7 +1659,7 @@ class EmpiricalIncomingAdmissionPredictor(IncomingAdmissionPredictor):
         num_days: Optional[int] = None,
         epsilon: float = 10**-7,
         y: Optional[None] = None,
-        stratify_by_weekday: bool = False,
+        stratify_by_weekday: Optional[bool] = None,
         *,
         start_time_col: str = "arrival_datetime",
         end_time_col: str = "departure_datetime",
@@ -1612,8 +1691,11 @@ class EmpiricalIncomingAdmissionPredictor(IncomingAdmissionPredictor):
             of the maximum value of the random variable representing number of beds.
         y : None, optional
             Ignored, present for compatibility with scikit-learn's fit method.
-        stratify_by_weekday : bool, default=False
-            Same as ``IncomingAdmissionPredictor.fit``.
+        stratify_by_weekday : bool or None, default=None
+            Same as ``IncomingAdmissionPredictor.fit``. The sentinel default
+            (``None``) fits weekday profiles silently; pass ``True`` explicitly
+            to activate the predict-time weekday contract (warns when
+            ``prediction_date`` is omitted), or ``False`` to opt out entirely.
         start_time_col : str, default='arrival_datetime'
             Name of the column containing the start time (e.g., arrival time).
             Expected to be the DataFrame index, but can also be a regular column.
@@ -1788,12 +1870,16 @@ class EmpiricalIncomingAdmissionPredictor(IncomingAdmissionPredictor):
         prediction_context : dict, optional
             Deprecated nested dict API.
         prediction_date : datetime.date, optional
-            Calendar anchor for weekday-stratified λ when fitted with
-            ``stratify_by_weekday=True``.
+            Calendar anchor for weekday-stratified λ. Under the library
+            default the pooled fallback is silent when ``prediction_date`` is
+            omitted; explicit ``stratify_by_weekday=True`` at fit time turns
+            that fallback into a ``UserWarning``. See
+            ``patientflow.aggregate.get_prob_dist_by_service`` for the
+            service-level helper that supplies ``prediction_date``
+            automatically per snapshot date.
         strict_prediction_date : bool, default=False
-            If ``True``, raise an error when ``prediction_date`` is provided but
-            weekday-stratified arrival rates are unavailable for a selected key.
-            If ``False``, warn and fall back to pooled arrival rates.
+            If ``True``, raise ``ValueError`` whenever a pooled-rate fallback
+            would occur — independent of fit-time opt-in.
         **kwargs
             Optional ``max_value``.
 

--- a/src/patientflow/viz/observed_against_expected.py
+++ b/src/patientflow/viz/observed_against_expected.py
@@ -14,7 +14,9 @@ plot_arrival_deltas : function
     Plot delta charts for multiple snapshot dates on the same figure
 """
 
-from datetime import timedelta, datetime, time
+from collections import OrderedDict
+from datetime import date as _date, timedelta, datetime, time
+from typing import Optional
 from patientflow.calculate.arrival_rates import time_varying_arrival_rates
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -483,6 +485,72 @@ def _prepare_common_values(prediction_time):
     return prediction_time_obj, default_datetime
 
 
+def _resolve_predictor_filter_key(predictor, filter_key):
+    weights = getattr(predictor, "weights", None)
+    if not isinstance(weights, dict) or len(weights) == 0:
+        raise ValueError("predictor.weights is empty; has the predictor been fit?")
+    if filter_key is None:
+        if len(weights) == 1:
+            return next(iter(weights.keys()))
+        raise ValueError(
+            "filter_key is required when predictor.weights has more than one "
+            f"key (e.g. multiple fitted services). Available keys: {sorted(weights.keys())}."
+        )
+    if filter_key not in weights:
+        raise ValueError(
+            f"filter_key '{filter_key}' is not recognized in predictor.weights. "
+            f"Available keys: {sorted(weights.keys())}."
+        )
+    return filter_key
+
+
+def _predictor_rates_for_window(
+    predictor,
+    filter_key: str,
+    prediction_time: tuple,
+    prediction_window: timedelta,
+    snapshot_date: _date,
+    strict_prediction_date: bool = False,
+) -> "OrderedDict[time, float]":
+    import warnings
+
+    weights = predictor.weights[filter_key]
+    arrival_rates_dict = weights.get("arrival_rates_dict")
+    if arrival_rates_dict is None:
+        raise ValueError(
+            f"No arrival_rates_dict found under filter '{filter_key}' on the "
+            "supplied predictor. Has the predictor been fit?"
+        )
+    by_weekday = weights.get("arrival_rates_by_weekday")
+
+    if by_weekday is None:
+        message = (
+            "predictor was fit without weekday stratification "
+            f"(filter '{filter_key}'). Pooled arrival rates will be used as "
+            "the expected baseline for every snapshot date."
+        )
+        if strict_prediction_date:
+            raise ValueError(message)
+        warnings.warn(message, UserWarning, stacklevel=3)
+
+    yta_time_interval = predictor.yta_time_interval
+    Ntimes = int(prediction_window / yta_time_interval)
+    anchor = datetime.combine(
+        snapshot_date, time(hour=prediction_time[0], minute=prediction_time[1])
+    )
+
+    rates: "OrderedDict[time, float]" = OrderedDict()
+    for i in range(Ntimes):
+        dt_i = anchor + i * yta_time_interval
+        t_i = dt_i.time()
+        if by_weekday is not None:
+            d_i = dt_i.weekday()
+            rates[t_i] = by_weekday[d_i][t_i]
+        else:
+            rates[t_i] = arrival_rates_dict[t_i]
+    return rates
+
+
 def plot_arrival_deltas(
     df,
     prediction_time,
@@ -493,36 +561,93 @@ def plot_arrival_deltas(
     file_name=None,
     return_figure=False,
     fig_size=(15, 6),
+    *,
+    predictor=None,
+    filter_key: Optional[str] = None,
+    strict_prediction_date: bool = False,
+    suptitle: Optional[str] = None,
 ):
     """Plot delta charts for multiple snapshot dates on the same figure.
 
     Parameters
     ----------
     df : pd.DataFrame
-        DataFrame containing arrival data
+        DataFrame containing arrival data.
     prediction_time : tuple
-        (hour, minute) of prediction time
+        ``(hour, minute)`` of prediction time.
     snapshot_dates : list
-        List of datetime.date objects to analyze
+        List of ``datetime.date`` objects to analyse.
     prediction_window : timedelta
-        Prediction window in minutes
-    yta_time_interval : int, default=15
-        Time interval in minutes for calculating arrival rates
+        Prediction window length.
+    yta_time_interval : timedelta, default=timedelta(minutes=15)
+        Time-interval grid for arrival rates. When ``predictor`` is supplied,
+        this must equal ``predictor.yta_time_interval``; otherwise a
+        ``ValueError`` is raised.
     media_file_path : Path, optional
-        Path to save the plot
+        Path to save the plot.
     file_name : str, optional
-        Custom filename to use when saving the plot. If not provided, defaults to "multiple_deltas.png"
+        Custom filename to use when saving the plot. If not provided, defaults
+        to ``"multiple_deltas.png"``.
     return_figure : bool, default=False
-        If True, returns the figure instead of displaying it
+        If True, returns the figure instead of displaying it.
     fig_size : tuple, default=(15, 6)
-        Figure size as (width, height) in inches
+        Figure size as ``(width, height)`` in inches.
+    predictor : IncomingAdmissionPredictor, optional
+        Fitted predictor whose stored arrival rates will be used as the
+        expected baseline. When the predictor's ``weights`` contain an
+        ``arrival_rates_by_weekday`` profile (the library-default fit), each
+        snapshot date uses the rates for its own weekday so the diagnostic
+        agrees with the deployed model. When ``predictor`` is ``None``
+        (default), the function falls back to pooled rates derived from
+        ``df`` (legacy behaviour).
+    filter_key : str, optional
+        Which ``weights`` key of ``predictor`` to read rates from. Required
+        only when the predictor has more than one fitted key (e.g. multiple
+        services). Ignored when ``predictor`` is ``None``.
+    strict_prediction_date : bool, default=False
+        Passed through to the predictor: when ``True`` and the predictor
+        lacks per-weekday rates for the supplied filter key, a
+        ``ValueError`` is raised instead of falling back to pooled rates.
+    suptitle : str, optional
+        Figure-level title. Typically the entity (service / specialty)
+        being analysed. Rendered above the per-axis titles.
 
     Returns
     -------
     matplotlib.figure.Figure or None
-        The figure object if return_figure is True, otherwise None
+        The figure object if return_figure is True, otherwise None.
+
+    Raises
+    ------
+    ValueError
+        If ``predictor`` is supplied and ``yta_time_interval`` does not match
+        ``predictor.yta_time_interval``, or if the predictor is unfitted /
+        the requested ``filter_key`` is unknown.
     """
-    # Create figure with subplots
+    if predictor is not None:
+        predictor_interval = getattr(predictor, "yta_time_interval", None)
+        if predictor_interval is None:
+            raise ValueError(
+                "predictor.yta_time_interval is not set; has the predictor " "been fit?"
+            )
+        if predictor_interval != yta_time_interval:
+            raise ValueError(
+                "yta_time_interval mismatch: plot_arrival_deltas was called with "
+                f"{yta_time_interval!r} but predictor.yta_time_interval is "
+                f"{predictor_interval!r}. Pass yta_time_interval=predictor."
+                "yta_time_interval to silence this error."
+            )
+        resolved_filter_key = _resolve_predictor_filter_key(predictor, filter_key)
+        baseline_source = (
+            "weekday-specific rates (from fitted predictor)"
+            if predictor.weights[resolved_filter_key].get("arrival_rates_by_weekday")
+            is not None
+            else "pooled rates (from fitted predictor)"
+        )
+    else:
+        resolved_filter_key = None
+        baseline_source = "pooled rates (from dataframe)"
+
     fig = plt.figure(figsize=fig_size)
     gs = plt.GridSpec(1, 2, width_ratios=[2, 1])
     ax1 = plt.subplot(gs[0])
@@ -556,9 +681,19 @@ def plot_arrival_deltas(
         arrivals["cumulative_count"] = range(1, len(arrivals) + 1)
 
         # Calculate arrival rates and prepare time points
-        mean_arrival_rates = _calculate_arrival_rates(
-            df_copy, prediction_time_obj, prediction_window, yta_time_interval
-        )
+        if predictor is not None:
+            mean_arrival_rates = _predictor_rates_for_window(
+                predictor,
+                resolved_filter_key,
+                prediction_time,
+                prediction_window,
+                snapshot_date,
+                strict_prediction_date=strict_prediction_date,
+            )
+        else:
+            mean_arrival_rates = _calculate_arrival_rates(
+                df_copy, prediction_time_obj, prediction_window, yta_time_interval
+            )
 
         # Prepare arrival times
         arrival_times_piecewise = _prepare_arrival_times(
@@ -666,8 +801,14 @@ def plot_arrival_deltas(
     ax1.set_xlabel("Time")
     ax1.set_ylabel("Difference (Actual - Expected)")
     ax1.set_title(
-        f"Difference Between Actual and Expected Arrivals in the {(int(prediction_window.total_seconds()/3600))} hours after {format_prediction_time(prediction_time)} on all dates"
+        f"Difference Between Actual and Expected Arrivals in the "
+        f"{(int(prediction_window.total_seconds()/3600))} hours after "
+        f"{format_prediction_time(prediction_time)} on all dates\n"
+        f"Expected baseline: {baseline_source}"
     )
+
+    if suptitle:
+        fig.suptitle(suptitle, fontsize=14)
 
     # Format time axis
     _format_time_axis(ax1, common_times)

--- a/tests/test_incoming_admission_predictors.py
+++ b/tests/test_incoming_admission_predictors.py
@@ -943,6 +943,308 @@ class TestIncomingAdmissionPredictors(unittest.TestCase):
             )
         self.assertIn("arrival_rates_by_weekday", str(cm.exception))
 
+    def test_weekday_rates_produced_by_default(self):
+        """fit() now emits per-weekday rates without an explicit opt-in."""
+        predictor = ParametricIncomingAdmissionPredictor(filters=self.filters)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        for key in self.filters:
+            self.assertIn(
+                "arrival_rates_by_weekday",
+                predictor.weights[key],
+                f"weekday profile missing for {key} when stratify_by_weekday default is used",
+            )
+            by_weekday = predictor.weights[key]["arrival_rates_by_weekday"]
+            self.assertEqual(set(by_weekday.keys()), set(range(7)))
+            # Each weekday profile spans the same 24-hour grid as the pooled profile
+            for d, profile in by_weekday.items():
+                self.assertEqual(len(profile), 48, f"weekday {d} has wrong size")
+
+    def test_empirical_weekday_rates_produced_by_default(self):
+        """EmpiricalIncomingAdmissionPredictor.fit() also defaults to weekday-aware."""
+        predictor = EmpiricalIncomingAdmissionPredictor(filters=self.filters)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        for key in self.filters:
+            self.assertIn("arrival_rates_by_weekday", predictor.weights[key])
+
+    def test_per_weekday_rates_differ_for_monday_only_data(self):
+        """Mondays-only synthetic data: Monday rates differ from other weekdays."""
+        times = []
+        for w in range(8):
+            for offset in range(0, 1000, 60):
+                t = datetime(2024, 1, 1, 10, 0) + timedelta(weeks=w, minutes=offset)
+                times.append(pd.Timestamp(t))
+        df = pd.DataFrame({"k": [1] * len(times)}, index=pd.DatetimeIndex(times))
+
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            df,
+            yta_time_interval=timedelta(hours=1),
+            num_days=60,
+        )
+        by_weekday = predictor.weights["unfiltered"]["arrival_rates_by_weekday"]
+        monday_total = sum(by_weekday[0].values())
+        for d in range(1, 7):
+            other_total = sum(by_weekday[d].values())
+            self.assertGreater(monday_total, other_total)
+
+    def test_default_fit_is_silent_when_prediction_date_omitted(self):
+        """Library-side default (sentinel) does NOT warn when prediction_date is omitted.
+
+        Option 1 semantics: weekday profiles are fitted by default but the
+        predict-time warning only fires when the caller explicitly opted in
+        via ``stratify_by_weekday=True``. Legacy callers see no new warnings
+        and predictions remain numerically unchanged.
+        """
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        # Default fit is treated as not-opted-in.
+        self.assertFalse(predictor._user_opted_in_to_weekday)
+        # Weekday profiles are still stored under the default.
+        self.assertIn("arrival_rates_by_weekday", predictor.weights["unfiltered"])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mean_no_date = predictor.predict_mean(
+                prediction_time=(8, 0),
+                prediction_window=self.prediction_window,
+            )
+        weekday_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "stratify_by_weekday=True" in str(w.message)
+        ]
+        self.assertEqual(
+            weekday_warnings,
+            [],
+            f"default fit should be silent, got: {[str(w.message) for w in caught]}",
+        )
+
+        # Predictions remain numerically unchanged vs. an explicit pooled-only fit.
+        opt_out = DirectAdmissionPredictor(filters=None)
+        opt_out.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+            stratify_by_weekday=False,
+        )
+        mean_pooled = opt_out.predict_mean(
+            prediction_time=(8, 0),
+            prediction_window=self.prediction_window,
+        )
+        self.assertAlmostEqual(mean_no_date, mean_pooled, places=10)
+
+    def test_explicit_opt_in_warns_when_prediction_date_omitted(self):
+        """Explicit stratify_by_weekday=True activates the predict-time contract."""
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+            stratify_by_weekday=True,
+        )
+        self.assertTrue(predictor._user_opted_in_to_weekday)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mean = predictor.predict_mean(
+                prediction_time=(8, 0),
+                prediction_window=self.prediction_window,
+            )
+        self.assertIsInstance(mean, float)
+        weekday_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "stratify_by_weekday=True" in str(w.message)
+            and "prediction_date" in str(w.message)
+        ]
+        self.assertTrue(
+            weekday_warnings,
+            f"explicit opt-in should warn, got {[str(w.message) for w in caught]}",
+        )
+
+    def test_strict_prediction_date_raises_on_omitted_date_under_default(self):
+        """strict_prediction_date=True forces the error path even under the default fit."""
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        # Default fit is silent on warnings, but strict at predict time still raises.
+        self.assertFalse(predictor._user_opted_in_to_weekday)
+        with self.assertRaises(ValueError) as cm:
+            predictor.predict_mean(
+                prediction_time=(8, 0),
+                prediction_window=self.prediction_window,
+                strict_prediction_date=True,
+            )
+        self.assertIn("prediction_date", str(cm.exception))
+
+    def test_strict_prediction_date_raises_on_omitted_date_under_opt_in(self):
+        """strict_prediction_date=True + explicit opt-in + omitted date → ValueError."""
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+            stratify_by_weekday=True,
+        )
+        with self.assertRaises(ValueError) as cm:
+            predictor.predict_mean(
+                prediction_time=(8, 0),
+                prediction_window=self.prediction_window,
+                strict_prediction_date=True,
+            )
+        self.assertIn("prediction_date", str(cm.exception))
+
+    def test_strict_prediction_date_raises_on_missing_profiles(self):
+        """strict_prediction_date=True surfaces silent fallback as ValueError."""
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+            stratify_by_weekday=False,
+        )
+        with self.assertRaises(ValueError) as cm:
+            predictor.predict_mean(
+                prediction_time=(8, 0),
+                prediction_window=self.prediction_window,
+                prediction_date=date(2024, 1, 8),
+                strict_prediction_date=True,
+            )
+        self.assertIn("arrival_rates_by_weekday", str(cm.exception))
+
+    def test_opt_out_preserves_pooled_only_behaviour(self):
+        """stratify_by_weekday=False reverts to pooled-only and matches legacy outputs."""
+        np.random.seed(123)
+        n = 600
+        start = datetime(2024, 1, 1)
+        rows = []
+        for _ in range(n):
+            t = start + timedelta(
+                days=np.random.randint(0, 31),
+                hours=np.random.randint(0, 24),
+                minutes=np.random.randint(0, 60),
+            )
+            rows.append(pd.Timestamp(t))
+        df = pd.DataFrame({"k": [1] * n}, index=pd.DatetimeIndex(sorted(rows)))
+
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            df,
+            yta_time_interval=timedelta(hours=1),
+            num_days=31,
+            stratify_by_weekday=False,
+        )
+        # No weekday profile is stored when opted out.
+        self.assertNotIn("arrival_rates_by_weekday", predictor.weights["unfiltered"])
+        mean = predictor.predict_mean(
+            prediction_time=(8, 0),
+            prediction_window=timedelta(hours=4),
+        )
+        # Regression value: total arrival rate over 4 hours starting at 08:00
+        pooled = predictor.weights["unfiltered"]["arrival_rates_dict"]
+        from datetime import time as _t
+
+        manual = sum(pooled[_t(hour=h)] for h in range(8, 12))
+        self.assertAlmostEqual(mean, manual, places=10)
+
+    def test_calculate_parameters_handles_empty_input(self):
+        """An empty filtered subset yields zero rates everywhere."""
+        predictor = ParametricIncomingAdmissionPredictor(filters=None)
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        empty_df = self.test_df.iloc[0:0]
+        out = predictor._calculate_parameters(
+            empty_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+            stratify_by_weekday=True,
+        )
+        self.assertIn("arrival_rates_dict", out)
+        self.assertIn("arrival_rates_by_weekday", out)
+        self.assertTrue(all(v == 0.0 for v in out["arrival_rates_dict"].values()))
+        for d in range(7):
+            self.assertTrue(
+                all(v == 0.0 for v in out["arrival_rates_by_weekday"][d].values())
+            )
+
+    def test_empty_filter_count_tracks_empty_subsets(self):
+        """fit() counts filters whose subset of train_df is empty."""
+        # All four configured filters have data in the synthetic dataset.
+        predictor = ParametricIncomingAdmissionPredictor(filters=self.filters)
+        # Fresh instances start at zero before fit.
+        self.assertEqual(predictor.empty_filter_count, 0)
+
+        predictor.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        self.assertEqual(predictor.empty_filter_count, 0)
+
+        # Add two filters guaranteed to miss every row, plus one that matches.
+        filters_with_misses = {
+            "medical": {"specialty": "medical"},
+            "no_such_specialty": {"specialty": "imaginary"},
+            "another_miss": {"specialty": "also_imaginary"},
+        }
+        predictor2 = ParametricIncomingAdmissionPredictor(filters=filters_with_misses)
+        predictor2.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        self.assertEqual(predictor2.empty_filter_count, 2)
+        # All filter keys still get weights — empty subsets produce zero rates.
+        for key in filters_with_misses:
+            self.assertIn(key, predictor2.weights)
+            self.assertIn("arrival_rates_dict", predictor2.weights[key])
+        # Empty subsets produce all-zero rates.
+        for key in ("no_such_specialty", "another_miss"):
+            self.assertTrue(
+                all(
+                    v == 0.0
+                    for v in predictor2.weights[key]["arrival_rates_dict"].values()
+                )
+            )
+
+        # Re-fitting against fully-matching data resets the counter.
+        predictor2.fit(
+            self.test_df.assign(specialty="medical"),
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        # 'medical' matches every row; the two imaginary specialties miss every row.
+        self.assertEqual(predictor2.empty_filter_count, 2)
+
+        # No-filters configuration leaves the counter at zero.
+        predictor3 = ParametricIncomingAdmissionPredictor(filters=None)
+        predictor3.fit(
+            self.test_df,
+            yta_time_interval=self.yta_time_interval,
+            num_days=self.num_days,
+        )
+        self.assertEqual(predictor3.empty_filter_count, 0)
+
     def test_legacy_prediction_context_with_prediction_date(self):
         predictor = DirectAdmissionPredictor(filters=self.filters)
         predictor.fit(

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -6,6 +6,9 @@ Tier 3: Render smoke tests — verify plotting functions produce figures without
 """
 
 import unittest
+import warnings
+from datetime import date, datetime, timedelta
+
 import numpy as np
 import pandas as pd
 import matplotlib
@@ -25,13 +28,20 @@ from patientflow.viz.randomised_pit import _prob_to_cdf
 from patientflow.viz.aspirational_curve import plot_curve
 from patientflow.viz.survival_curve import plot_admission_time_survival_curve
 from patientflow.viz.data_distribution import plot_data_distribution
-from patientflow.viz.observed_against_expected import plot_deltas
+from patientflow.viz.observed_against_expected import (
+    plot_deltas,
+    plot_arrival_deltas,
+    _predictor_rates_for_window,
+)
 from patientflow.viz.arrival_rates import (
     plot_arrival_rates,
     plot_cumulative_arrival_rates,
 )
 from patientflow.viz.trial_results import plot_trial_results
 from patientflow.model_artifacts import HyperParameterTrial
+from patientflow.predictors.incoming_admission_predictors import (
+    DirectAdmissionPredictor,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -368,6 +378,163 @@ class TestPlotRendering(unittest.TestCase):
         fig = plot_trial_results(trials, return_figure=True)
         self.assertIsInstance(fig, Figure)
         self.assertEqual(len(fig.axes), 2)
+
+
+class TestPlotArrivalDeltas(unittest.TestCase):
+    """Tests for plot_arrival_deltas with and without a fitted predictor."""
+
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(7)
+        rows = []
+        for w in range(8):
+            base = datetime(2024, 1, 1) + timedelta(weeks=w)
+            for d in range(7):
+                day = base + timedelta(days=d)
+                # Mondays receive many arrivals; other days receive few.
+                n = 40 if d == 0 else 4
+                for _ in range(n):
+                    rows.append(
+                        pd.Timestamp(
+                            day
+                            + timedelta(
+                                hours=int(np.random.randint(0, 24)),
+                                minutes=int(np.random.randint(0, 60)),
+                            )
+                        )
+                    )
+        cls.df = pd.DataFrame({"arrival_datetime": sorted(rows)})
+        cls.prediction_window = timedelta(hours=4)
+        cls.yta_time_interval = timedelta(hours=1)
+
+        # Snapshot dates: a Monday and a Tuesday (matching the synthetic gradient).
+        cls.snapshot_dates = [date(2024, 1, 1), date(2024, 1, 2)]
+
+    def tearDown(self):
+        plt.close("all")
+
+    def _make_predictor(self, *, stratify_by_weekday=True):
+        df_for_fit = self.df.set_index("arrival_datetime")
+        predictor = DirectAdmissionPredictor(filters=None)
+        predictor.fit(
+            df_for_fit,
+            yta_time_interval=self.yta_time_interval,
+            num_days=56,
+            stratify_by_weekday=stratify_by_weekday,
+        )
+        return predictor
+
+    def test_predictor_rates_for_window_uses_weekday_profile(self):
+        """Helper returns rates from arrival_rates_by_weekday when available."""
+        predictor = self._make_predictor()
+        rates_mon = _predictor_rates_for_window(
+            predictor,
+            "unfiltered",
+            (8, 0),
+            self.prediction_window,
+            date(2024, 1, 1),  # Monday
+        )
+        rates_tue = _predictor_rates_for_window(
+            predictor,
+            "unfiltered",
+            (8, 0),
+            self.prediction_window,
+            date(2024, 1, 2),  # Tuesday
+        )
+        self.assertGreater(sum(rates_mon.values()), sum(rates_tue.values()))
+
+    def test_plot_with_predictor_uses_weekday_baseline(self):
+        """Annotation indicates weekday-specific predictor baseline was used."""
+        predictor = self._make_predictor()
+        fig = plot_arrival_deltas(
+            self.df,
+            prediction_time=(8, 0),
+            snapshot_dates=self.snapshot_dates,
+            prediction_window=self.prediction_window,
+            yta_time_interval=self.yta_time_interval,
+            predictor=predictor,
+            return_figure=True,
+        )
+        self.assertIsInstance(fig, Figure)
+        title_text = fig.axes[0].get_title()
+        self.assertIn("weekday-specific rates (from fitted predictor)", title_text)
+
+    def test_plot_without_predictor_uses_pooled_baseline(self):
+        """Default path falls back to pooled rates derived from the dataframe."""
+        fig = plot_arrival_deltas(
+            self.df,
+            prediction_time=(8, 0),
+            snapshot_dates=self.snapshot_dates,
+            prediction_window=self.prediction_window,
+            yta_time_interval=self.yta_time_interval,
+            return_figure=True,
+        )
+        self.assertIsInstance(fig, Figure)
+        title_text = fig.axes[0].get_title()
+        self.assertIn("pooled rates (from dataframe)", title_text)
+
+    def test_plot_raises_on_yta_interval_mismatch(self):
+        """yta_time_interval must match predictor.yta_time_interval."""
+        predictor = self._make_predictor()
+        with self.assertRaises(ValueError) as cm:
+            plot_arrival_deltas(
+                self.df,
+                prediction_time=(8, 0),
+                snapshot_dates=self.snapshot_dates,
+                prediction_window=self.prediction_window,
+                yta_time_interval=timedelta(minutes=30),
+                predictor=predictor,
+                return_figure=True,
+            )
+        self.assertIn("yta_time_interval mismatch", str(cm.exception))
+
+    def test_plot_with_pooled_predictor_uses_pooled_predictor_baseline(self):
+        """Predictor without weekday profiles → 'pooled rates (from fitted predictor)'."""
+        predictor = self._make_predictor(stratify_by_weekday=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            fig = plot_arrival_deltas(
+                self.df,
+                prediction_time=(8, 0),
+                snapshot_dates=self.snapshot_dates,
+                prediction_window=self.prediction_window,
+                yta_time_interval=self.yta_time_interval,
+                predictor=predictor,
+                return_figure=True,
+            )
+        self.assertIsInstance(fig, Figure)
+        title_text = fig.axes[0].get_title()
+        self.assertIn("pooled rates (from fitted predictor)", title_text)
+
+    def test_plot_strict_raises_when_predictor_lacks_weekday(self):
+        """strict_prediction_date=True surfaces missing weekday profiles."""
+        predictor = self._make_predictor(stratify_by_weekday=False)
+        with self.assertRaises(ValueError):
+            plot_arrival_deltas(
+                self.df,
+                prediction_time=(8, 0),
+                snapshot_dates=self.snapshot_dates,
+                prediction_window=self.prediction_window,
+                yta_time_interval=self.yta_time_interval,
+                predictor=predictor,
+                strict_prediction_date=True,
+                return_figure=True,
+            )
+
+    def test_plot_with_suptitle_renders_supertitle(self):
+        """suptitle renders as the figure-level title."""
+        predictor = self._make_predictor()
+        fig = plot_arrival_deltas(
+            self.df,
+            prediction_time=(8, 0),
+            snapshot_dates=self.snapshot_dates,
+            prediction_window=self.prediction_window,
+            yta_time_interval=self.yta_time_interval,
+            predictor=predictor,
+            suptitle="Medical service",
+            return_figure=True,
+        )
+        self.assertEqual(fig._suptitle.get_text(), "Medical service")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# PR summary: YTA weekday-aware arrival rates (default) + aligned diagnostics

## What problem does this solve?

Hospital arrival patterns differ by weekday. Pooling all days into one 24-hour profile dulls peaks on busy weekdays and inflates quiet ones. Yet-to-arrive (YTA) admission predictors previously defaulted to pooled-only rates unless callers knew to pass `stratify_by_weekday=True`.

The arrival-delta diagnostic (`plot_arrival_deltas`) also computed its own pooled baseline from the supplied dataframe, so charts could disagree with the rates stored in a deployed fitted model.

## What changed

### `IncomingAdmissionPredictor` (and subclasses)

- **Default fit behaviour:** `stratify_by_weekday` now defaults to **`None`**, resolved inside `fit()` to **`True`** so both **pooled** (`arrival_rates_dict`) and **per-weekday** (`arrival_rates_by_weekday`, Monday=0 … Sunday=6) profiles are stored by default.
- **Explicit opt-in contract:** If the caller passes **`stratify_by_weekday=True`**, the weekday contract applies at predict time: omitting `prediction_date` on a weekday-aware weight emits a **`UserWarning`** and falls back to pooled rates (numeric behaviour unchanged). Under the library default (`None`), that fallback is **silent** so legacy callers are not spammed.
- **`strict_prediction_date`:** On `predict()` / `predict_mean()`, when `True`, **any** pooled-rate fallback raises **`ValueError`** instead of warning—useful for evaluation pipelines regardless of fit-time opt-in.
- **`prediction_date`:** Threaded through the predict path; windows that cross midnight use the correct next-calendar-day weekday for later slices.
- **`empty_filter_count`:** New integer attribute, reset each `fit()`, incremented once per **configured filter** whose subset of `train_df` is empty. Helps spot typos or services absent from the training window while still fitting zero-rate weights for those keys.
- **Empty subsets:** `_calculate_parameters` returns zero rates for all intervals (and per weekday when stratifying) when a filtered subset is empty, instead of failing downstream.

### `plot_arrival_deltas` (`observed_against_expected.py`)

- Optional **`predictor=`**: expected cumulative arrivals can be built from the **same stored rates** as production (including weekday-specific slices per snapshot date when profiles exist).
- **`filter_key`**, **`strict_prediction_date`**, **`suptitle`** for multi-service predictors and stricter failure modes.
- **`yta_time_interval`** must match **`predictor.yta_time_interval`** or a clear **`ValueError`** is raised.
- The main panel title includes a second line documenting the **expected baseline source**, e.g. *weekday-specific rates (from fitted predictor)* vs *pooled rates (from dataframe)*.

### Tests

- Extended `tests/test_incoming_admission_predictors.py` and `tests/test_viz.py` for defaults, opt-in warnings, strict mode, midnight crossing, empty filters, and `plot_arrival_deltas` behaviour.

## Behavioural notes

- **No new warnings for existing code paths** that never passed `stratify_by_weekday=True`: default fit stores weekday profiles quietly; missing `prediction_date` stays silent unless explicitly opted in at fit time or `strict_prediction_date=True`.
- **Opt out:** `stratify_by_weekday=False` restores pooled-only storage (no `arrival_rates_by_weekday` on weights).

## Files changed

- `src/patientflow/predictors/incoming_admission_predictors.py`
- `src/patientflow/viz/observed_against_expected.py`
- `tests/test_incoming_admission_predictors.py`
- `tests/test_viz.py`


