### PR TITLE
Thread prediction date to build service data

### DIFF
--- a/src/patientflow/predict/service.py
+++ b/src/patientflow/predict/service.py
@@ -14,6 +14,7 @@ schemes) implemented elsewhere.
 """
 
 from dataclasses import dataclass
+from datetime import date
 from typing import Dict, List, Optional, Tuple, Union, Any
 
 import numpy as np
@@ -836,6 +837,7 @@ def _create_flow_inputs(
     y1: float,
     x2: float,
     y2: float,
+    prediction_date: Optional[date] = None,
 ) -> Dict[str, Dict[str, FlowInputs]]:
     """Create FlowInputs objects for inflows and outflows.
 
@@ -856,6 +858,7 @@ def _create_flow_inputs(
                 prediction_time=prediction_time,
                 prediction_window=prediction_window,
                 filter_key=spec,
+                prediction_date=prediction_date,
                 **kwargs,
             )
         )
@@ -954,6 +957,7 @@ def _build_legacy_flows(
     x2: float,
     y2: float,
     base_probs: Dict[str, Any],
+    prediction_date: Optional[date] = None,
 ) -> Dict[str, Dict[str, Any]]:
     """Build flows for all specialties using processing logic.
 
@@ -1029,6 +1033,7 @@ def _build_legacy_flows(
             y1,
             x2,
             y2,
+            prediction_date=prediction_date,
         )
 
         # Store in temporary dictionary structure
@@ -1123,6 +1128,7 @@ def build_service_data(
     y2: float,
     cdf_cut_points: Optional[List[float]] = None,
     use_admission_in_window_prob: bool = True,
+    prediction_date: Optional[date] = None,
 ) -> Dict[str, ServicePredictionInputs]:
     """Build per-service inputs for downstream roll-up.
 
@@ -1166,6 +1172,12 @@ def build_service_data(
     use_admission_in_window_prob : bool, default=True
         Whether to weight current ED admissions by their probability of being
         admitted within the prediction window.
+    prediction_date : datetime.date, optional
+        Calendar date at the inference ``prediction_time``. When provided, YTA
+        Poisson means use per-weekday arrival profiles for models fitted with
+        weekday stratification (the default for incoming admission predictors).
+        When omitted (default), behaviour matches previous releases: pooled
+        profiles are used and legacy callers stay warning-free.
 
     Returns
     -------
@@ -1229,6 +1241,7 @@ def build_service_data(
         x2,
         y2,
         base_probs,
+        prediction_date=prediction_date,
     )
 
     # 4. Finalize with transfers

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import timedelta
+from datetime import date, timedelta
 
 import numpy as np
 import pandas as pd
@@ -551,6 +551,70 @@ class TestBuildServiceData(unittest.TestCase):
             y2=self.y2,
         )
         self.assertIn("paediatric", result)
+
+    def test_prediction_date_threads_to_yta_means(self):
+        """Weekday-skewed YTA fits yield different Poisson means when prediction_date differs."""
+        mon = pd.Timestamp("2024-06-03 07:30:00")
+        tue = pd.Timestamp("2024-06-04 07:30:00")
+        rows = []
+        for _ in range(200):
+            rows.append(
+                {"arrival_datetime": mon, "specialty": "medical", "is_child": False}
+            )
+        for _ in range(5):
+            rows.append(
+                {"arrival_datetime": tue, "specialty": "medical", "is_child": False}
+            )
+        skewed_arrivals = pd.DataFrame(rows)
+
+        direct_non_ed = _create_direct_predictor(
+            self.prediction_window, self.train_df, skewed_arrivals
+        )
+        direct_elective = _create_direct_predictor(
+            self.prediction_window, self.train_df, skewed_arrivals
+        )
+        param_yta = _create_parametric_yta_model(
+            self.prediction_window, self.train_df, skewed_arrivals
+        )
+        models = (
+            self.admissions_model,
+            self.inpatient_discharge_model,
+            self.spec_model,
+            param_yta,
+            direct_non_ed,
+            direct_elective,
+            self.transfer_model,
+        )
+        ed_snapshots = self._make_snapshots(20)
+        inpatient_snapshots = self._make_inpatient_snapshots(10)
+        base_kwargs = dict(
+            models=models,
+            prediction_time=self.prediction_time,
+            ed_snapshots=ed_snapshots,
+            inpatient_snapshots=inpatient_snapshots,
+            specialties=self.specialties,
+            prediction_window=self.prediction_window,
+            x1=self.x1,
+            y1=self.y1,
+            x2=self.x2,
+            y2=self.y2,
+        )
+        mon_date = date(2024, 6, 3)
+        tue_date = date(2024, 6, 4)
+        r_mon = build_service_data(**base_kwargs, prediction_date=mon_date)
+        r_tue = build_service_data(**base_kwargs, prediction_date=tue_date)
+        lam_mon = r_mon["medical"].inflows["elective_yta"].distribution
+        lam_tue = r_tue["medical"].inflows["elective_yta"].distribution
+        self.assertIsInstance(lam_mon, float)
+        self.assertIsInstance(lam_tue, float)
+        self.assertGreater(abs(lam_mon - lam_tue), 1e-6)
+
+        r_none_a = build_service_data(**base_kwargs)
+        r_none_b = build_service_data(**base_kwargs)
+        self.assertEqual(
+            r_none_a["medical"].inflows["elective_yta"].distribution,
+            r_none_b["medical"].inflows["elective_yta"].distribution,
+        )
 
 
 class TestComputeTransferArrivals(unittest.TestCase):


### PR DESCRIPTION
Adds optional prediction_date: Optional[date] = None to build_service_data and passes it into every YTA predict_mean call (ED parametric/empirical, non-ED, elective) via _build_legacy_flows → _create_flow_inputs. When omitted, behaviour is unchanged (pooled rates, existing warning rules on the predictors). When set, weekday-stratified arrival rates are used for models that have them.
