### PR TITLE
Support different prediction windows per prediction time

### DIFF
--- a/docs/notebooks/4d_Evaluate_demand_predictions.md
+++ b/docs/notebooks/4d_Evaluate_demand_predictions.md
@@ -50,6 +50,9 @@ Public ED extracts omit `departure_datetime`; this notebook synthesises leave-ED
 You can request the UCLH datasets on [Zenodo](https://zenodo.org/records/14866057). If you do not have the public data, set `data_folder_name` to `'data-synthetic'`.
 
 ```python
+from typing import Any
+
+
 from patientflow.train.emergency_demand import prepare_prediction_inputs
 from patientflow.prepare import create_temporal_splits
 from patientflow.load import get_model_key
@@ -72,6 +75,7 @@ x1, y1, x2, y2 = params["x1"], params["y1"], params["x2"], params["y2"]
 prediction_window = timedelta(minutes=params["prediction_window"])
 yta_time_interval = timedelta(minutes=params["yta_time_interval"])
 prediction_times = params["prediction_times"]
+prediction_dict = {tuple[Any, ...](pt): prediction_window for pt in prediction_times}
 
 start_training_set = params["start_training_set"]
 start_validation_set = params["start_validation_set"]
@@ -370,7 +374,7 @@ flow_sel_ed_current = FlowSelection.custom(
 ed_current_by_service = {svc: {} for svc in specialties}
 ed_yta_by_service = {svc: {} for svc in specialties}
 
-for prediction_time in prediction_times:
+for prediction_time, prediction_window in prediction_dict.items():
     model_key = get_model_key(model_name, prediction_time)
     admission_model = admissions_models[model_key]
     service_models = ServiceModels(
@@ -485,16 +489,16 @@ print(ed_yta_by_service[demo_specialty][demo_model_key][demo_snapshot_date]['agg
 
     ED current snapshots predicted distribution for surgical service on 2031-09-16:
           agg_proba
-    0  1.272620e-01
+    0  1.272621e-01
     1  2.217735e-01
     2  2.928779e-01
     3  2.256789e-01
     4  1.014280e-01
     5  2.655857e-02
     6  4.044790e-03
-    7  3.575432e-04
+    7  3.575431e-04
     8  1.830299e-05
-    9  5.413717e-07
+    9  5.413715e-07
     ... (44 total)
 
     ED current snapshots observed values for number admitted at some point to surgical service on 2031-09-16:
@@ -630,7 +634,7 @@ eval_flow_selection = FlowSelection.custom(
 
 builder = EvaluationInputsBuilder(
     flow_selection=eval_flow_selection,
-    prediction_times=prediction_times,
+    prediction_dict=prediction_dict,
     eval_split=eval_split,
 ).with_evaluation_targets(evaluation_targets)
 
@@ -650,7 +654,7 @@ builder.add_classifier(
 
 ```
 
-    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>
+    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>
 
 ### 3d. Add ED current bed demand evaluation task to the builder
 
@@ -670,13 +674,12 @@ obs_ed_current_by_service = {service: eval_visits_df for service in specialties}
 # add the observed values to the builder
 builder.add_distribution_observations(
     flow_name="ed_current_beds",
-    prediction_window=prediction_window,
     ed_visits_by_service=obs_ed_current_by_service,
 )
 
 ```
 
-    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>
+    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>
 
 ### 3e. Add ED yet-to-arrive bed demand evaluation task to the builder.
 
@@ -701,13 +704,12 @@ obs_ed_yta_by_service = {
 # add the observed values to the builder
 builder.add_distribution_observations(
     "ed_yta_beds",
-    prediction_window=prediction_window,
     inpatient_arrivals_by_service=obs_ed_yta_by_service,
 )
 
 ```
 
-    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>
+    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>
 
 ### 3f. Add ED yet-to-arrive arrival deltas to the evaluation task
 
@@ -718,7 +720,6 @@ builder.add_arrival_deltas(
     flow_name="ed_yta_arrival_rates",
     arrivals_by_service=obs_ed_yta_by_service,
     snapshot_dates=eval_snapshot_dates,
-    prediction_window=prediction_window,
     yta_time_interval=yta_time_interval,
     predictors_by_service={s: yta_model_by_spec for s in specialties},
     filter_keys_by_service={s: s for s in specialties},
@@ -726,7 +727,7 @@ builder.add_arrival_deltas(
 
 ```
 
-    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>
+    <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>
 
 ### 3g. Build `EvaluationInputs`
 
@@ -760,33 +761,47 @@ from datetime import datetime
 from patientflow.evaluate.runner import run_evaluation
 
 run_name = f"notebook4d_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-out = run_evaluation(Path("eval-output"), inputs, run_name=run_name)
+out = run_evaluation(
+    Path("eval-output"),
+    inputs,
+    run_name=run_name,
+    training_metadata={
+        "start_training_set": str(start_training_set),
+        "start_validation_set": str(start_validation_set),
+        "start_test_set": str(start_test_set),
+        "end_test_set": str(end_test_set),
+        "yta_time_interval_minutes": int(yta_time_interval.total_seconds() // 60),
+    },
+)
 out
 
 ```
 
-    Predicted classification (not admitted, admitted):  [662 399]
-
-
-    Predicted classification (not admitted, admitted):  [1039  505]
-
-
-    Predicted classification (not admitted, admitted):  [1751  809]
-
-
-    Predicted classification (not admitted, admitted):  [1918  944]
-
-
-    Predicted classification (not admitted, admitted):  [1549  839]
+    /Users/zellaking/miniconda3/envs/patientflow/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
+      from .autonotebook import tqdm as notebook_tqdm
 
 
 
+    ---------------------------------------------------------------------------
+
+    KeyError                                  Traceback (most recent call last)
+
+    Cell In[18], line 11
+          3 from patientflow.evaluate.runner import run_evaluation
+          5 run_name = f"notebook4d_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+          6 out = run_evaluation(
+          7     Path("eval-output"),
+          8     inputs,
+          9     run_name=run_name,
+         10     training_metadata={
+    ---> 11         "modelling_dates": params["modelling_dates"],
+         12         "yta_time_interval_minutes": int(yta_time_interval.total_seconds() // 60),
+         13     },
+         14 )
+         15 out
 
 
-    {'run_dir': PosixPath('eval-output/notebook4d_20260519_121044'),
-     'scalars_path': PosixPath('eval-output/notebook4d_20260519_121044/scalars.json'),
-     'manifest_path': PosixPath('eval-output/notebook4d_20260519_121044/evaluation_run.yaml'),
-     'n_targets': 5}
+    KeyError: 'modelling_dates'
 
 ## 5. Review outputs
 

--- a/notebooks/4d_Evaluate_demand_predictions.ipynb
+++ b/notebooks/4d_Evaluate_demand_predictions.ipynb
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-19T11:10:29.507054Z",
@@ -93,6 +93,9 @@
     }
    ],
    "source": [
+    "from typing import Any\n",
+    "\n",
+    "\n",
     "from patientflow.train.emergency_demand import prepare_prediction_inputs\n",
     "from patientflow.prepare import create_temporal_splits\n",
     "from patientflow.load import get_model_key\n",
@@ -115,6 +118,7 @@
     "prediction_window = timedelta(minutes=params[\"prediction_window\"])\n",
     "yta_time_interval = timedelta(minutes=params[\"yta_time_interval\"])\n",
     "prediction_times = params[\"prediction_times\"]\n",
+    "prediction_dict = {tuple[Any, ...](pt): prediction_window for pt in prediction_times}\n",
     "\n",
     "start_training_set = params[\"start_training_set\"]\n",
     "start_validation_set = params[\"start_validation_set\"]\n",
@@ -552,7 +556,7 @@
     "ed_current_by_service = {svc: {} for svc in specialties}\n",
     "ed_yta_by_service = {svc: {} for svc in specialties}\n",
     "\n",
-    "for prediction_time in prediction_times:\n",
+    "for prediction_time, prediction_window in prediction_dict.items():\n",
     "    model_key = get_model_key(model_name, prediction_time)\n",
     "    admission_model = admissions_models[model_key]\n",
     "    service_models = ServiceModels(\n",
@@ -661,16 +665,16 @@
      "text": [
       "ED current snapshots predicted distribution for surgical service on 2031-09-16:\n",
       "      agg_proba\n",
-      "0  1.272620e-01\n",
+      "0  1.272621e-01\n",
       "1  2.217735e-01\n",
       "2  2.928779e-01\n",
       "3  2.256789e-01\n",
       "4  1.014280e-01\n",
       "5  2.655857e-02\n",
       "6  4.044790e-03\n",
-      "7  3.575432e-04\n",
+      "7  3.575431e-04\n",
       "8  1.830299e-05\n",
-      "9  5.413717e-07\n",
+      "9  5.413715e-07\n",
       "... (44 total)\n",
       "\n",
       "ED current snapshots observed values for number admitted at some point to surgical service on 2031-09-16:\n",
@@ -868,7 +872,7 @@
     "\n",
     "builder = EvaluationInputsBuilder(\n",
     "    flow_selection=eval_flow_selection,\n",
-    "    prediction_times=prediction_times,\n",
+    "    prediction_dict=prediction_dict,\n",
     "    eval_split=eval_split,\n",
     ").with_evaluation_targets(evaluation_targets)\n"
    ]
@@ -897,7 +901,7 @@
     {
      "data": {
       "text/plain": [
-       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>"
+       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>"
       ]
      },
      "execution_count": 13,
@@ -938,7 +942,7 @@
     {
      "data": {
       "text/plain": [
-       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>"
+       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>"
       ]
      },
      "execution_count": 14,
@@ -960,7 +964,6 @@
     "# add the observed values to the builder\n",
     "builder.add_distribution_observations(\n",
     "    flow_name=\"ed_current_beds\",\n",
-    "    prediction_window=prediction_window,\n",
     "    ed_visits_by_service=obs_ed_current_by_service,\n",
     ")\n"
    ]
@@ -989,7 +992,7 @@
     {
      "data": {
       "text/plain": [
-       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>"
+       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>"
       ]
      },
      "execution_count": 15,
@@ -1016,7 +1019,6 @@
     "# add the observed values to the builder\n",
     "builder.add_distribution_observations(\n",
     "    \"ed_yta_beds\",\n",
-    "    prediction_window=prediction_window,\n",
     "    inpatient_arrivals_by_service=obs_ed_yta_by_service,\n",
     ")\n"
    ]
@@ -1045,7 +1047,7 @@
     {
      "data": {
       "text/plain": [
-       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x119828890>"
+       "<patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>"
       ]
      },
      "execution_count": 16,
@@ -1058,7 +1060,6 @@
     "    flow_name=\"ed_yta_arrival_rates\",\n",
     "    arrivals_by_service=obs_ed_yta_by_service,\n",
     "    snapshot_dates=eval_snapshot_dates,\n",
-    "    prediction_window=prediction_window,\n",
     "    yta_time_interval=yta_time_interval,\n",
     "    predictors_by_service={s: yta_model_by_spec for s in specialties},\n",
     "    filter_keys_by_service={s: s for s in specialties},\n",
@@ -1131,52 +1132,23 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Predicted classification (not admitted, admitted):  [662 399]\n"
+      "/Users/zellaking/miniconda3/envs/patientflow/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted classification (not admitted, admitted):  [1039  505]\n"
+     "ename": "KeyError",
+     "evalue": "'modelling_dates'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[18]\u001b[39m\u001b[32m, line 11\u001b[39m\n\u001b[32m      3\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpatientflow\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mevaluate\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mrunner\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m run_evaluation\n\u001b[32m      5\u001b[39m run_name = \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mnotebook4d_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdatetime.now().strftime(\u001b[33m'\u001b[39m\u001b[33m%\u001b[39m\u001b[33mY\u001b[39m\u001b[33m%\u001b[39m\u001b[33mm\u001b[39m\u001b[38;5;132;01m%d\u001b[39;00m\u001b[33m_\u001b[39m\u001b[33m%\u001b[39m\u001b[33mH\u001b[39m\u001b[33m%\u001b[39m\u001b[33mM\u001b[39m\u001b[33m%\u001b[39m\u001b[33mS\u001b[39m\u001b[33m'\u001b[39m)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m      6\u001b[39m out = run_evaluation(\n\u001b[32m      7\u001b[39m     Path(\u001b[33m\"\u001b[39m\u001b[33meval-output\u001b[39m\u001b[33m\"\u001b[39m),\n\u001b[32m      8\u001b[39m     inputs,\n\u001b[32m      9\u001b[39m     run_name=run_name,\n\u001b[32m     10\u001b[39m     training_metadata={\n\u001b[32m---> \u001b[39m\u001b[32m11\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mmodelling_dates\u001b[39m\u001b[33m\"\u001b[39m: \u001b[43mparams\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mmodelling_dates\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m,\n\u001b[32m     12\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33myta_time_interval_minutes\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mint\u001b[39m(yta_time_interval.total_seconds() // \u001b[32m60\u001b[39m),\n\u001b[32m     13\u001b[39m     },\n\u001b[32m     14\u001b[39m )\n\u001b[32m     15\u001b[39m out\n",
+      "\u001b[31mKeyError\u001b[39m: 'modelling_dates'"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted classification (not admitted, admitted):  [1751  809]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted classification (not admitted, admitted):  [1918  944]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Predicted classification (not admitted, admitted):  [1549  839]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'run_dir': PosixPath('eval-output/notebook4d_20260519_121044'),\n",
-       " 'scalars_path': PosixPath('eval-output/notebook4d_20260519_121044/scalars.json'),\n",
-       " 'manifest_path': PosixPath('eval-output/notebook4d_20260519_121044/evaluation_run.yaml'),\n",
-       " 'n_targets': 5}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1185,7 +1157,18 @@
     "from patientflow.evaluate.runner import run_evaluation\n",
     "\n",
     "run_name = f\"notebook4d_{datetime.now().strftime('%Y%m%d_%H%M%S')}\"\n",
-    "out = run_evaluation(Path(\"eval-output\"), inputs, run_name=run_name)\n",
+    "out = run_evaluation(\n",
+    "    Path(\"eval-output\"),\n",
+    "    inputs,\n",
+    "    run_name=run_name,\n",
+    "    training_metadata={\n",
+    "        \"start_training_set\": str(start_training_set),\n",
+    "        \"start_validation_set\": str(start_validation_set),\n",
+    "        \"start_test_set\": str(start_test_set),\n",
+    "        \"end_test_set\": str(end_test_set),\n",
+    "        \"yta_time_interval_minutes\": int(yta_time_interval.total_seconds() // 60),\n",
+    "    },\n",
+    ")\n",
     "out\n"
    ]
   },
@@ -1200,7 +1183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-19T11:11:01.650495Z",
@@ -1542,7 +1525,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/src/patientflow/evaluate/handlers.py
+++ b/src/patientflow/evaluate/handlers.py
@@ -26,6 +26,7 @@ from patientflow.evaluate.inputs import (
     EvaluationInputs,
     EvaluationTarget,
     eval_split_label,
+    prediction_times_from_dict,
 )
 from patientflow.evaluate.observations import (
     admission_type_filter_for_distribution_component,
@@ -523,11 +524,11 @@ def _recompute_distribution_observed_counts(
     target: EvaluationTarget,
     service: str,
     model_name: str,
-    prediction_times: Sequence[Tuple[int, int]],
-    prediction_window: timedelta,
+    prediction_dict: Mapping[Tuple[int, int], timedelta],
     observation_frame: pd.DataFrame,
 ) -> None:
     """Update `agg_observed` on every leaf in a per-service distribution tree."""
+    prediction_times = prediction_times_from_dict(prediction_dict)
     if _distribution_per_date_is_model_key_indexed(
         per_date, model_name, prediction_times
     ):
@@ -545,7 +546,7 @@ def _recompute_distribution_observed_counts(
                     service=service,
                     snapshot_date=_coerce_snapshot_date(snap),
                     prediction_time=pt,
-                    prediction_window=prediction_window,
+                    prediction_window=prediction_dict[pt],
                     observation_frame=observation_frame,
                 )
         return
@@ -564,7 +565,7 @@ def _recompute_distribution_observed_counts(
                 service=service,
                 snapshot_date=snap_date,
                 prediction_time=pt,
-                prediction_window=prediction_window,
+                prediction_window=prediction_dict[pt],
                 observation_frame=observation_frame,
             )
 
@@ -899,13 +900,7 @@ def evaluate_distribution(
         return
     prob_by_svc: Mapping[str, Any] = block.get("prob_dist_by_service") or {}
     model_name: str = str(block.get("model_name") or "admissions")
-    prediction_window = block.get("prediction_window")
-    if prediction_window is None:
-        raise ValueError(
-            f"distribution block for flow {target.flow_name!r} has no "
-            "prediction_window; call add_distribution_observations with "
-            "prediction_window=..."
-        )
+    prediction_dict = inputs.prediction_dict
     if not prob_by_svc:
         collector.merge_service_summary_slice(
             f"{target.evaluation_mode}/{target.flow_name}/{target.component}",
@@ -935,8 +930,7 @@ def evaluate_distribution(
             target=target,
             service=str(service),
             model_name=model_name,
-            prediction_times=inputs.prediction_times,
-            prediction_window=prediction_window,
+            prediction_dict=prediction_dict,
             observation_frame=observation_frame,
         )
         inactive = _service_is_inactive_distribution(
@@ -1056,7 +1050,7 @@ def evaluate_arrival_deltas(
         return
     by_svc: Mapping[str, pd.DataFrame] = block.get("arrivals_by_service") or {}
     snap_dates: Sequence[date] = block.get("snapshot_dates") or []
-    pred_window = block["prediction_window"]
+    prediction_dict = inputs.prediction_dict
     predictors = block.get("predictors_by_service") or {}
     filter_keys = block.get("filter_keys_by_service") or {}
     strict_map = block.get("strict_prediction_date_by_service") or {}
@@ -1099,7 +1093,7 @@ def evaluate_arrival_deltas(
                 df,
                 pt,
                 list(snap_dates),
-                pred_window,
+                prediction_dict[pt],
                 yta_time_interval=yta_iv,
                 media_file_path=out_dir,
                 file_name=fname,

--- a/src/patientflow/evaluate/inputs.py
+++ b/src/patientflow/evaluate/inputs.py
@@ -91,6 +91,49 @@ def _validate_eval_split(eval_split: str) -> EvalSplitLiteral:
     return eval_split  # type: ignore[return-value]
 
 
+def normalize_prediction_dict(
+    prediction_dict: Mapping[Tuple[int, int], timedelta],
+) -> Dict[Tuple[int, int], timedelta]:
+    """Validate and copy a prediction schedule (clock time → horizon).
+
+    Parameters
+    ----------
+    prediction_dict : mapping
+        Keys are ``(hour, minute)``; values are prediction horizons.
+
+    Returns
+    -------
+    dict
+        Normalised copy with integer hour/minute keys.
+
+    Raises
+    ------
+    ValueError
+        If the mapping is empty or keys/values have wrong types.
+    """
+    if not prediction_dict:
+        raise ValueError("prediction_dict must not be empty")
+    normalized: Dict[Tuple[int, int], timedelta] = {}
+    for key, window in prediction_dict.items():
+        if not isinstance(key, tuple) or len(key) != 2:
+            raise ValueError(
+                f"prediction_dict keys must be (hour, minute) tuples; got {key!r}"
+            )
+        if not isinstance(window, timedelta):
+            raise ValueError(
+                f"prediction_dict values must be timedelta; got {type(window).__name__}"
+            )
+        normalized[(int(key[0]), int(key[1]))] = window
+    return normalized
+
+
+def prediction_times_from_dict(
+    prediction_dict: Mapping[Tuple[int, int], timedelta],
+) -> List[Tuple[int, int]]:
+    """Return prediction clock times in ascending order."""
+    return sorted(prediction_dict.keys())
+
+
 @dataclass(frozen=True)
 class EvaluationTarget:
     """Describe one evaluation slice (one scalar row family in `scalars.json`).
@@ -160,9 +203,10 @@ class EvaluationInputs:
     ----------
     flow_selection : FlowSelection
         Single scenario for the run (required once per evaluation).
+    prediction_dict : dict
+        Maps each ``(hour, minute)`` clock time to its prediction horizon.
     prediction_times : list of tuple of int
-        Global `(hour, minute)` list shared by classifiers, distributions, and
-        arrival-delta targets.
+        Sorted keys of ``prediction_dict`` (ascending by hour, then minute).
     evaluation_targets : list of EvaluationTarget
         Targets the runner dispatches over.
     classifier_by_flow : dict
@@ -170,7 +214,7 @@ class EvaluationInputs:
         "model_name"}` (``model_name`` is the prefix for :func:`get_model_key`).
     distribution_by_flow : dict
         Nested `flow_name` → distribution block (`prob_dist_by_service`,
-        `model_name`, `prediction_window`, etc.).
+        `model_name`, etc.).
     arrival_by_flow : dict
         Nested `flow_name` → arrival-delta block (dataframes, snapshot dates,
         predictors, optional filter keys).
@@ -184,8 +228,9 @@ class EvaluationInputs:
     """
 
     flow_selection: FlowSelection
-    prediction_times: List[Tuple[int, int]]
+    prediction_dict: Dict[Tuple[int, int], timedelta]
     evaluation_targets: List[EvaluationTarget]
+    prediction_times: List[Tuple[int, int]] = field(default_factory=list)
     eval_split: EvalSplitLiteral = "valid"
     classifier_by_flow: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     distribution_by_flow: Dict[str, Dict[str, Any]] = field(default_factory=dict)
@@ -195,11 +240,15 @@ class EvaluationInputs:
         default_factory=dict
     )
 
+    def __post_init__(self) -> None:
+        if not self.prediction_times:
+            self.prediction_times = prediction_times_from_dict(self.prediction_dict)
+
 
 class EvaluationInputsBuilder:
     """Construct `EvaluationInputs` with a fluent `add_*` API.
 
-    `flow_selection`, `prediction_times`, and `eval_split` must be set
+    `flow_selection`, `prediction_dict`, and `eval_split` must be set
     (via the constructor or setters) before any `add_*` method is called.
     Register visit frames and snapshot dates for the same holdout as
     ``eval_split``.
@@ -208,8 +257,9 @@ class EvaluationInputsBuilder:
     ----------
     flow_selection : FlowSelection, optional
         Scenario for the run; may be set later via `set_flow_selection`.
-    prediction_times : list of tuple of int, optional
-        Global prediction clock times; may be set via `set_prediction_times`.
+    prediction_dict : mapping, optional
+        Maps each ``(hour, minute)`` to a ``timedelta`` horizon (uclhflow
+        ``prediction.prediction_dict`` shape). May be set via `set_prediction_dict`.
     eval_split : str, optional
         Holdout for this run: ``"valid"`` (default) or ``"test"``. May be set
         later via `set_eval_split`.
@@ -218,12 +268,14 @@ class EvaluationInputsBuilder:
     def __init__(
         self,
         flow_selection: Optional[FlowSelection] = None,
-        prediction_times: Optional[List[Tuple[int, int]]] = None,
+        prediction_dict: Optional[Mapping[Tuple[int, int], timedelta]] = None,
         *,
         eval_split: EvalSplitLiteral = "valid",
     ) -> None:
         self._flow_selection: Optional[FlowSelection] = flow_selection
-        self._prediction_times: Optional[List[Tuple[int, int]]] = prediction_times
+        self._prediction_dict: Optional[Dict[Tuple[int, int], timedelta]] = (
+            normalize_prediction_dict(prediction_dict) if prediction_dict else None
+        )
         self._eval_split: EvalSplitLiteral = _validate_eval_split(eval_split)
         self._targets: List[EvaluationTarget] = []
         self._classifier_by_flow: Dict[str, Dict[str, Any]] = {}
@@ -250,22 +302,24 @@ class EvaluationInputsBuilder:
         self._flow_selection = flow_selection
         return self
 
-    def set_prediction_times(
-        self, prediction_times: List[Tuple[int, int]]
+    def set_prediction_dict(
+        self,
+        prediction_dict: Mapping[Tuple[int, int], timedelta],
     ) -> EvaluationInputsBuilder:
-        """Set the ordered global prediction times.
+        """Set the run-level prediction schedule (time → horizon).
 
         Parameters
         ----------
-        prediction_times : list of tuple of int
-            Each tuple is `(hour, minute)`.
+        prediction_dict : mapping
+            Each key is ``(hour, minute)``; each value is the horizon for that
+            clock time.
 
         Returns
         -------
         EvaluationInputsBuilder
             `self` for method chaining.
         """
-        self._prediction_times = list(prediction_times)
+        self._prediction_dict = normalize_prediction_dict(prediction_dict)
         return self
 
     def set_eval_split(self, eval_split: EvalSplitLiteral) -> EvaluationInputsBuilder:
@@ -312,8 +366,8 @@ class EvaluationInputsBuilder:
     def _require_basics(self) -> None:
         if self._flow_selection is None:
             raise ValueError("flow_selection must be set before adding inputs.")
-        if not self._prediction_times:
-            raise ValueError("prediction_times must be set before adding inputs.")
+        if not self._prediction_dict:
+            raise ValueError("prediction_dict must be set before adding inputs.")
 
     def add_classifier(
         self,
@@ -352,7 +406,7 @@ class EvaluationInputsBuilder:
         Raises
         ------
         ValueError
-            If `flow_selection` or `prediction_times` has not been set.
+            If `flow_selection` or `prediction_dict` has not been set.
         """
         self._require_basics()
         models = _normalize_trained_models(trained_models)
@@ -390,7 +444,7 @@ class EvaluationInputsBuilder:
         Raises
         ------
         ValueError
-            If `flow_selection` or `prediction_times` has not been set.
+            If `flow_selection` or `prediction_dict` has not been set.
         """
         self._require_basics()
         block = self._distribution_by_flow.setdefault(
@@ -398,7 +452,6 @@ class EvaluationInputsBuilder:
             {
                 "prob_dist_by_service": {},
                 "model_name": model_name,
-                "prediction_window": None,
             },
         )
         block["model_name"] = model_name
@@ -410,7 +463,6 @@ class EvaluationInputsBuilder:
     def add_distribution_observations(
         self,
         flow_name: str,
-        prediction_window: timedelta,
         *,
         ed_visits_by_service: Optional[Mapping[str, pd.DataFrame]] = None,
         inpatient_arrivals_by_service: Optional[Mapping[str, pd.DataFrame]] = None,
@@ -418,14 +470,14 @@ class EvaluationInputsBuilder:
     ) -> EvaluationInputsBuilder:
         """Attach per-service observation frames for distribution evaluation.
 
+        Observation horizons come from the builder's ``prediction_dict`` (per
+        clock time). Before plotting, :func:`evaluate_distribution` recomputes
+        ``agg_observed`` via :func:`count_observed` for each leaf.
+
         Parameters
         ----------
         flow_name : str
             Must match `EvaluationTarget.flow_name` for targets that use this block.
-        prediction_window : datetime.timedelta
-            Horizon stored on the distribution block and passed to
-            `count_observed` when `evaluate_distribution` recomputes
-            `agg_observed`.
         ed_visits_by_service : mapping, optional
             `service` → ED snapshot dataframe (`ed_visits` context key).
         inpatient_arrivals_by_service : mapping, optional
@@ -441,7 +493,7 @@ class EvaluationInputsBuilder:
         Raises
         ------
         ValueError
-            If `flow_selection` or `prediction_times` has not been set, or if
+            If `flow_selection` or `prediction_dict` has not been set, or if
             no observation mapping is provided.
         """
         if not any(
@@ -457,15 +509,13 @@ class EvaluationInputsBuilder:
                 "inpatient_visits_by_service"
             )
         self._require_basics()
-        block = self._distribution_by_flow.setdefault(
+        self._distribution_by_flow.setdefault(
             flow_name,
             {
                 "prob_dist_by_service": {},
                 "model_name": "admissions",
-                "prediction_window": prediction_window,
             },
         )
-        block["prediction_window"] = prediction_window
         obs_ctx = self._observation_contexts.setdefault(flow_name, {})
 
         def _register(
@@ -487,7 +537,6 @@ class EvaluationInputsBuilder:
         flow_name: str,
         arrivals_by_service: Mapping[str, pd.DataFrame],
         snapshot_dates: Sequence[date],
-        prediction_window: timedelta,
         *,
         predictors_by_service: Optional[Mapping[str, Any]] = None,
         filter_keys_by_service: Optional[Mapping[str, Optional[str]]] = None,
@@ -495,6 +544,9 @@ class EvaluationInputsBuilder:
         yta_time_interval: timedelta = timedelta(minutes=15),
     ) -> EvaluationInputsBuilder:
         """Register arrival data and optional predictors for delta plots.
+
+        Horizons for each prediction clock come from the builder's
+        ``prediction_dict``.
 
         Parameters
         ----------
@@ -505,8 +557,6 @@ class EvaluationInputsBuilder:
             inactive-service detection).
         snapshot_dates : sequence of datetime.date
             Dates passed to `patientflow.viz.observed_against_expected.plot_arrival_deltas`.
-        prediction_window : datetime.timedelta
-            Horizon for delta charts.
         predictors_by_service : mapping, optional
             Fitted incoming-admission predictors keyed by service (optional).
         filter_keys_by_service : mapping, optional
@@ -525,13 +575,12 @@ class EvaluationInputsBuilder:
         Raises
         ------
         ValueError
-            If `flow_selection` or `prediction_times` has not been set.
+            If `flow_selection` or `prediction_dict` has not been set.
         """
         self._require_basics()
         self._arrival_by_flow[flow_name] = {
             "arrivals_by_service": {str(k): v for k, v in arrivals_by_service.items()},
             "snapshot_dates": list(snapshot_dates),
-            "prediction_window": prediction_window,
             "predictors_by_service": dict(predictors_by_service or {}),
             "filter_keys_by_service": dict(filter_keys_by_service or {}),
             "strict_prediction_date_by_service": dict(
@@ -572,7 +621,7 @@ class EvaluationInputsBuilder:
         Raises
         ------
         ValueError
-            If `flow_selection` or `prediction_times` has not been set.
+            If `flow_selection` or `prediction_dict` has not been set.
         """
         self._require_basics()
         self._survival = {
@@ -595,17 +644,19 @@ class EvaluationInputsBuilder:
         Raises
         ------
         ValueError
-            If `flow_selection` or `prediction_times` is missing.
+            If `flow_selection` or `prediction_dict` is missing.
         """
         if self._flow_selection is None:
             raise ValueError("flow_selection is required to build EvaluationInputs.")
-        if not self._prediction_times:
-            raise ValueError("prediction_times is required to build EvaluationInputs.")
+        if not self._prediction_dict:
+            raise ValueError("prediction_dict is required to build EvaluationInputs.")
         if not self._targets:
             self._targets = []
+        prediction_dict = dict(self._prediction_dict)
         return EvaluationInputs(
             flow_selection=self._flow_selection,
-            prediction_times=list(self._prediction_times),
+            prediction_dict=prediction_dict,
+            prediction_times=prediction_times_from_dict(prediction_dict),
             evaluation_targets=list(self._targets),
             eval_split=self._eval_split,
             classifier_by_flow=dict(self._classifier_by_flow),

--- a/src/patientflow/evaluate/runner.py
+++ b/src/patientflow/evaluate/runner.py
@@ -13,10 +13,11 @@ patientflow.evaluate.inputs.EvaluationInputsBuilder
 
 from __future__ import annotations
 
+import json
 from dataclasses import asdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 import yaml
 
@@ -37,44 +38,30 @@ try:
 except Exception:  # pragma: no cover
     pass
 
+from importlib.metadata import version as package_version
+
 EVALUATION_RUN_MANIFEST = "evaluation_run.yaml"
 
 
-def _load_yaml_mapping(path: Path) -> Dict[str, Any]:
-    if not path.is_file():
-        return {}
-    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
-    return dict(loaded) if isinstance(loaded, dict) else {}
+def _patientflow_version() -> str:
+    try:
+        return package_version("patientflow")
+    except Exception:
+        return "unknown"
 
 
-def _resolve_project_config_path(project_config_path: Optional[Path] = None) -> Path:
-    """Locate the repository ``config.yaml`` for manifest snapshots.
+def prediction_dict_for_manifest(
+    prediction_dict: Mapping[Tuple[int, int], timedelta],
+) -> Dict[str, float]:
+    """Serialise a prediction schedule for ``evaluation_run.yaml``.
 
-    Search order: explicit path (if it exists), ``config.yaml`` in the current
-    working directory, each parent of the cwd (so notebooks under ``notebooks/``
-    still find the repo root), then ``config.yaml`` next to the installed package
-    source tree.
+    Keys use uclhflow-style stringified ``[hour, minute]`` tuples; values are
+    horizon length in hours.
     """
-    if project_config_path is not None:
-        explicit = Path(project_config_path)
-        if explicit.is_file():
-            return explicit.resolve()
-
-    candidates: list[Path] = [Path.cwd() / "config.yaml"]
-    candidates.extend(parent / "config.yaml" for parent in Path.cwd().parents)
-    repo_root = Path(__file__).resolve().parents[3]
-    candidates.append(repo_root / "config.yaml")
-
-    seen: set[Path] = set()
-    for candidate in candidates:
-        resolved = candidate.resolve()
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        if resolved.is_file():
-            return resolved
-
-    return (project_config_path or Path.cwd() / "config.yaml").resolve()
+    return {
+        json.dumps(list(pt)): window.total_seconds() / 3600.0
+        for pt, window in sorted(prediction_dict.items())
+    }
 
 
 def write_evaluation_run_manifest(
@@ -83,14 +70,14 @@ def write_evaluation_run_manifest(
     output_root: Path,
     run_name: str,
     inputs: EvaluationInputs,
-    project_config_path: Optional[Path] = None,
+    training_metadata: Optional[Mapping[str, Any]] = None,
 ) -> Path:
-    """Write ``evaluation_run.yaml`` with project training config and run settings.
+    """Write ``evaluation_run.yaml`` describing this evaluation run.
 
-    The ``training`` block is a copy of the project ``config.yaml`` (including
-    ``prediction_times`` and date boundaries). The ``evaluation`` block holds
-    only settings specific to this run (paths, ``flow_selection``, ``eval_split``,
-    target count).
+    The ``evaluation`` block records run settings and the ``prediction_dict``
+    schedule used. An optional ``training_metadata`` block may be supplied by the
+    caller (for example uclhflow splits or aspirational curve parameters);
+    patientflow does not load or copy any repository ``config.yaml`` by default.
 
     Parameters
     ----------
@@ -102,28 +89,28 @@ def write_evaluation_run_manifest(
         Run subdirectory name (timestamp or custom).
     inputs : EvaluationInputs
         Built evaluation inputs.
-    project_config_path : pathlib.Path, optional
-        Path to the repository ``config.yaml``. When omitted, searches the cwd,
-        its parents, then the package source tree (works when the notebook cwd
-        is ``notebooks/``).
+    training_metadata : mapping, optional
+        Caller-supplied YAML-serialisable training context (not auto-discovered).
 
     Returns
     -------
     pathlib.Path
         Path to the written manifest file.
     """
-    config_path = _resolve_project_config_path(project_config_path)
-    training_config = _load_yaml_mapping(config_path)
     manifest: Dict[str, Any] = {
-        "training": training_config,
         "evaluation": {
             "output_root": str(output_root),
             "run_name": run_name,
             "eval_split": inputs.eval_split,
             "flow_selection": asdict(inputs.flow_selection),
             "n_targets": len(inputs.evaluation_targets),
+            "prediction_dict": prediction_dict_for_manifest(inputs.prediction_dict),
+            "patientflow_version": _patientflow_version(),
         },
     }
+    if training_metadata is not None:
+        manifest["training_metadata"] = dict(training_metadata)
+
     manifest_path = run_dir / EVALUATION_RUN_MANIFEST
     manifest_path.write_text(
         yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8"
@@ -136,15 +123,15 @@ def run_evaluation(
     inputs: EvaluationInputs,
     *,
     run_name: Optional[str] = None,
-    project_config_path: Optional[Path] = None,
+    training_metadata: Optional[Mapping[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Execute every `EvaluationTarget` in `inputs` and write artefacts.
 
     Creates a timestamped subdirectory under `output_root` containing:
 
-    - `evaluation_run.yaml` — full project ``config.yaml`` under ``training:``,
-      plus evaluation-only settings under ``evaluation:`` (including
-      ``eval_split``).
+    - `evaluation_run.yaml` — run settings under ``evaluation:`` (including
+      ``prediction_dict`` and ``eval_split``), plus optional caller
+      ``training_metadata``.
     - `scalars.json` — `evaluation_rows` plus optional `_service_summary`
       fragments merged by handlers (distribution and arrival modes attach
       per-slice service coverage).
@@ -167,8 +154,9 @@ def run_evaluation(
         Immutable inputs from `EvaluationInputsBuilder.build()`.
     run_name : str, optional
         Subdirectory name; default is `YYYYMMDD_HHMMSS` from the current time.
-    project_config_path : pathlib.Path, optional
-        Project ``config.yaml`` to snapshot under ``training`` in the manifest.
+    training_metadata : mapping, optional
+        Optional training context written under ``training_metadata`` in the
+        manifest (caller-defined; not loaded from patientflow ``config.yaml``).
 
     Returns
     -------
@@ -191,7 +179,7 @@ def run_evaluation(
         output_root=output_root,
         run_name=stamp,
         inputs=inputs,
-        project_config_path=project_config_path,
+        training_metadata=training_metadata,
     )
 
     classifiers_dir = run_dir / "classifiers"

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 
 from patientflow.evaluate.handlers import (
     _arrival_delta_suptitle,
@@ -22,11 +23,22 @@ from patientflow.evaluate.inputs import (
     EvaluationInputsBuilder,
     EvaluationTarget,
     eval_split_label,
+    normalize_prediction_dict,
 )
-from patientflow.evaluate.runner import write_evaluation_run_manifest
+from patientflow.evaluate.runner import (
+    prediction_dict_for_manifest,
+    write_evaluation_run_manifest,
+)
 from patientflow.evaluate.scalars import ScalarsCollector
 from patientflow.load import get_model_key
 from patientflow.predict.demand import FlowSelection
+
+
+def _uniform_prediction_dict(
+    times: list[tuple[int, int]], *, hours: float = 8.0
+) -> dict[tuple[int, int], timedelta]:
+    window = timedelta(hours=hours)
+    return {pt: window for pt in times}
 
 
 # --- eval_split: inputs and manifest ---
@@ -42,7 +54,7 @@ def test_eval_split_label():
 def test_builder_defaults_eval_split_valid():
     builder = EvaluationInputsBuilder(
         flow_selection=FlowSelection.emergency_only(),
-        prediction_times=[(6, 0)],
+        prediction_dict=_uniform_prediction_dict([(6, 0)]),
     )
     inputs = builder.build()
     assert inputs.eval_split == "valid"
@@ -51,7 +63,7 @@ def test_builder_defaults_eval_split_valid():
 def test_builder_set_eval_split_test():
     builder = EvaluationInputsBuilder(
         flow_selection=FlowSelection.emergency_only(),
-        prediction_times=[(6, 0)],
+        prediction_dict=_uniform_prediction_dict([(6, 0)]),
         eval_split="test",
     ).set_eval_split("test")
     inputs = builder.build()
@@ -64,7 +76,7 @@ def test_builder_rejects_unknown_eval_split():
 
     builder = EvaluationInputsBuilder(
         flow_selection=FlowSelection.emergency_only(),
-        prediction_times=[(6, 0)],
+        prediction_dict=_uniform_prediction_dict([(6, 0)]),
     )
     with pytest.raises(ValueError, match="Unknown eval_split"):
         builder.set_eval_split("train")  # type: ignore[arg-type]
@@ -74,11 +86,25 @@ def test_eval_splits_constant():
     assert EVAL_SPLITS == ("valid", "test")
 
 
-def test_manifest_records_eval_split(tmp_path: Path):
+def test_builder_requires_non_empty_prediction_dict():
+    with pytest.raises(ValueError, match="prediction_dict must not be empty"):
+        normalize_prediction_dict({})
+
+
+def test_prediction_times_derived_sorted():
+    inputs = EvaluationInputsBuilder(
+        flow_selection=FlowSelection.emergency_only(),
+        prediction_dict={(22, 0): timedelta(hours=8), (6, 0): timedelta(hours=4)},
+    ).build()
+    assert inputs.prediction_times == [(6, 0), (22, 0)]
+
+
+def test_manifest_records_eval_split_and_prediction_dict(tmp_path: Path):
     flow = FlowSelection.emergency_only()
+    prediction_dict = _uniform_prediction_dict([(6, 0), (12, 0)])
     inputs = EvaluationInputs(
         flow_selection=flow,
-        prediction_times=[(6, 0)],
+        prediction_dict=prediction_dict,
         evaluation_targets=[],
         eval_split="test",
     )
@@ -89,10 +115,33 @@ def test_manifest_records_eval_split(tmp_path: Path):
         output_root=tmp_path,
         run_name="run",
         inputs=inputs,
-        project_config_path=tmp_path / "missing_config.yaml",
     )
-    text = manifest_path.read_text(encoding="utf-8")
-    assert "eval_split: test" in text
+    loaded = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert "training" not in loaded
+    assert loaded["evaluation"]["eval_split"] == "test"
+    assert loaded["evaluation"]["prediction_dict"] == prediction_dict_for_manifest(
+        prediction_dict
+    )
+    assert "patientflow_version" in loaded["evaluation"]
+
+
+def test_manifest_optional_training_metadata(tmp_path: Path):
+    inputs = EvaluationInputs(
+        flow_selection=FlowSelection.emergency_only(),
+        prediction_dict=_uniform_prediction_dict([(6, 0)]),
+        evaluation_targets=[],
+    )
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_evaluation_run_manifest(
+        run_dir,
+        output_root=tmp_path,
+        run_name="run",
+        inputs=inputs,
+        training_metadata={"start_validation_set": "2025-10-01"},
+    )
+    loaded = yaml.safe_load((run_dir / "evaluation_run.yaml").read_text())
+    assert loaded["training_metadata"]["start_validation_set"] == "2025-10-01"
 
 
 # --- eval_split: handler suptitles ---
@@ -196,30 +245,25 @@ def _model_key_distribution(
 def test_add_distribution_observations_requires_a_frame_mapping():
     builder = EvaluationInputsBuilder(
         flow_selection=FlowSelection.emergency_only(),
-        prediction_times=[(10, 0)],
+        prediction_dict=_uniform_prediction_dict([(10, 0)]),
     )
     with pytest.raises(ValueError, match="at least one of"):
-        builder.add_distribution_observations(
-            "flow",
-            prediction_window=timedelta(hours=8),
-        )
+        builder.add_distribution_observations("flow")
 
 
 def test_add_distribution_observations_stores_distinct_frame_keys():
     builder = EvaluationInputsBuilder(
         flow_selection=FlowSelection.emergency_only(),
-        prediction_times=[(10, 0)],
+        prediction_dict=_uniform_prediction_dict([(10, 0)]),
     )
     ed = pd.DataFrame({"snapshot_date": [date(2024, 1, 1)]})
     arrivals = pd.DataFrame({"arrival_datetime": [datetime(2024, 1, 1, 11, 0)]})
     builder.add_distribution_observations(
         "ed_flow",
-        prediction_window=timedelta(hours=8),
         ed_visits_by_service={"medical": ed},
     )
     builder.add_distribution_observations(
         "yta_flow",
-        prediction_window=timedelta(hours=8),
         inpatient_arrivals_by_service={"medical": arrivals},
     )
     inputs = builder.build()
@@ -259,7 +303,7 @@ def test_evaluate_distribution_recomputes_yta_from_inpatient_arrivals(
     inputs = (
         EvaluationInputsBuilder(
             flow_selection=FlowSelection.emergency_only(),
-            prediction_times=[prediction_time],
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
         )
         .with_evaluation_targets([target])
         .add_distributions_from_service_dict(
@@ -273,7 +317,6 @@ def test_evaluate_distribution_recomputes_yta_from_inpatient_arrivals(
         )
         .add_distribution_observations(
             "ed_yta_beds",
-            prediction_window=timedelta(hours=8),
             ed_visits_by_service={"medical": ed_visits},
             inpatient_arrivals_by_service={"medical": inpatient_arrivals},
         )
@@ -289,6 +332,72 @@ def test_evaluate_distribution_recomputes_yta_from_inpatient_arrivals(
     assert leaf["agg_observed"] == 1
 
 
+def test_evaluate_distribution_uses_per_time_prediction_window(tmp_path: Path):
+    """Each clock time uses its own horizon from prediction_dict."""
+    snapshot = date(2024, 1, 1)
+    pt_short = (10, 0)
+    pt_long = (14, 0)
+    model_name = "beds"
+    moment_short = datetime(2024, 1, 1, 10, 0, 0)
+    moment_long = datetime(2024, 1, 1, 14, 0, 0)
+    # 5 h after 10:00 is outside a 4 h window; 5 h after 14:00 is inside 8 h.
+    arrivals_short = pd.DataFrame(
+        {"arrival_datetime": [moment_short + timedelta(hours=5)]}
+    )
+    arrivals_long = pd.DataFrame(
+        {"arrival_datetime": [moment_long + timedelta(hours=5)]}
+    )
+    leaf_short = _distribution_leaf()
+    leaf_long = _distribution_leaf()
+
+    target = EvaluationTarget(
+        flow_name="ed_yta_beds",
+        flow_type="admissions",
+        evaluation_mode="distribution",
+        component="bed_demand_ed_yta",
+        observation_mode="arrived_in_window",
+    )
+    inputs = (
+        EvaluationInputsBuilder(
+            flow_selection=FlowSelection.emergency_only(),
+            prediction_dict={
+                pt_short: timedelta(hours=4),
+                pt_long: timedelta(hours=8),
+            },
+        )
+        .with_evaluation_targets([target])
+        .add_distributions_from_service_dict(
+            "ed_yta_beds",
+            prob_dist_by_service={
+                "svc_a": _model_key_distribution(
+                    model_name, pt_short, snapshot, leaf_short
+                ),
+                "svc_b": _model_key_distribution(
+                    model_name, pt_long, snapshot, leaf_long
+                ),
+            },
+            model_name=model_name,
+        )
+        .add_distribution_observations(
+            "ed_yta_beds",
+            inpatient_arrivals_by_service={
+                "svc_a": arrivals_short,
+                "svc_b": arrivals_long,
+            },
+        )
+        .build()
+    )
+
+    evaluate_distribution(
+        inputs,
+        target,
+        distributions_dir=tmp_path / "distributions",
+        collector=ScalarsCollector(),
+    )
+    assert leaf_short["agg_observed"] == 0
+    assert leaf_long["agg_observed"] == 1
+
+
 def test_evaluate_distribution_yta_pre_filtered_cohort_not_specialty_column(
     tmp_path: Path,
 ):
@@ -297,7 +406,6 @@ def test_evaluate_distribution_yta_pre_filtered_cohort_not_specialty_column(
     prediction_time = (6, 0)
     model_name = "beds"
     moment = datetime(2031, 9, 4, 6, 0, 0)
-    window = timedelta(hours=8)
 
     inpatient_arrivals = pd.DataFrame(
         {
@@ -322,7 +430,7 @@ def test_evaluate_distribution_yta_pre_filtered_cohort_not_specialty_column(
     inputs = (
         EvaluationInputsBuilder(
             flow_selection=FlowSelection.emergency_only(),
-            prediction_times=[prediction_time],
+            prediction_dict={prediction_time: timedelta(hours=8)},
         )
         .with_evaluation_targets([target])
         .add_distributions_from_service_dict(
@@ -336,7 +444,6 @@ def test_evaluate_distribution_yta_pre_filtered_cohort_not_specialty_column(
         )
         .add_distribution_observations(
             "ed_yta_beds",
-            prediction_window=window,
             inpatient_arrivals_by_service={"paediatric": paediatric_cohort},
         )
         .build()
@@ -385,7 +492,7 @@ def test_evaluate_distribution_ed_current_applies_specialty_on_shared_frame(
     inputs = (
         EvaluationInputsBuilder(
             flow_selection=FlowSelection.emergency_only(),
-            prediction_times=[prediction_time],
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
         )
         .with_evaluation_targets([target])
         .add_distributions_from_service_dict(
@@ -402,7 +509,6 @@ def test_evaluate_distribution_ed_current_applies_specialty_on_shared_frame(
         )
         .add_distribution_observations(
             "ed_current_beds",
-            prediction_window=timedelta(hours=8),
             ed_visits_by_service={
                 "medical": ed_visits,
                 "surgical": ed_visits,
@@ -446,7 +552,7 @@ def test_evaluate_distribution_asserts_on_leaf_mismatch(tmp_path: Path):
     inputs = (
         EvaluationInputsBuilder(
             flow_selection=FlowSelection.emergency_only(),
-            prediction_times=[prediction_time],
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
         )
         .with_evaluation_targets([target])
         .add_distributions_from_service_dict(
@@ -460,7 +566,6 @@ def test_evaluate_distribution_asserts_on_leaf_mismatch(tmp_path: Path):
         )
         .add_distribution_observations(
             "ed_current_beds",
-            prediction_window=timedelta(hours=8),
             ed_visits_by_service={"medical": ed_visits},
         )
         .build()
@@ -507,7 +612,7 @@ def test_evaluate_distribution_departures_admission_type_filter(tmp_path: Path):
     inputs = (
         EvaluationInputsBuilder(
             flow_selection=FlowSelection.emergency_only(),
-            prediction_times=[prediction_time],
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
         )
         .with_evaluation_targets([target])
         .add_distributions_from_service_dict(
@@ -521,7 +626,6 @@ def test_evaluate_distribution_departures_admission_type_filter(tmp_path: Path):
         )
         .add_distribution_observations(
             "departures_elective",
-            prediction_window=timedelta(hours=8),
             inpatient_visits_by_service={"medical": inpatient_visits},
         )
         .build()
@@ -546,7 +650,7 @@ def test_evaluate_distribution_raises_when_observation_frame_missing():
     inputs = (
         EvaluationInputsBuilder(
             flow_selection=FlowSelection.emergency_only(),
-            prediction_times=[(10, 0)],
+            prediction_dict=_uniform_prediction_dict([(10, 0)]),
         )
         .with_evaluation_targets([target])
         .add_distributions_from_service_dict(
@@ -563,7 +667,6 @@ def test_evaluate_distribution_raises_when_observation_frame_missing():
         )
         .add_distribution_observations(
             "ed_yta_beds",
-            prediction_window=timedelta(hours=8),
             ed_visits_by_service={"medical": pd.DataFrame()},
         )
         .build()


### PR DESCRIPTION

- Require run-level prediction_dict on EvaluationInputsBuilder; derive sorted prediction_times from its keys
- Remove scalar prediction_window from add_distribution_observations and add_arrival_deltas Use inputs.prediction_dict[pt] when recomputing distribution observations and plotting arrival deltas
- Write evaluation_run.yaml with evaluation.prediction_dict and patientflow_version; stop copying repo config.yaml
- Add optional training_metadata on run_evaluation for caller-supplied context
- Update notebook 4d and tests, including per-time window recomputation coverage