### PR TITLE
Add rPIT + CvM calibration to distribution evaluation

### DIFF
--- a/docs/notebooks/4d_Evaluate_demand_predictions.md
+++ b/docs/notebooks/4d_Evaluate_demand_predictions.md
@@ -30,7 +30,7 @@ In this notebook I show the following:
 
 1. **Load data** — same pattern as notebook 4c: `prepare_prediction_inputs`, temporal splits, synthetic `departure_datetime` on evaluation ED visits and inpatient arrivals where extracts omit those timestamps.
 2. **Demonstrate pairing** of observed values with predicted distributions, under different values of `observation_mode`
-3. **Demonstrate the evaluate package** — `EvaluationInputsBuilder` with `flow_selection`, `prediction_times`, `eval_split`, and a custom `evaluation_targets` list whose `flow_name` keys match `add_classifier` / `add_distributions_*` / `add_arrival_deltas`. Distribution targets pair `add_distributions_from_service_dict` with `add_distribution_observations`. For arrival deltas with a multi-service predictor, pass `predictors_by_service` and `filter_keys_by_service` so the baseline matches each service.
+3. **Demonstrate the evaluate package** — `EvaluationInputsBuilder` with `flow_selection`, `prediction_times`, `eval_split`, and a custom `evaluation_targets` list whose `flow_name` keys match `add_classifier` / `add_distributions_*` / `add_arrival_deltas`. Distribution targets pair `add_distributions_from_service_dict` with `add_distribution_observations`, and **`add_distribution_benchmark_cohort`** for the Binomial-benchmark on admission-style modes. For arrival deltas with a multi-service predictor, pass `predictors_by_service` and `filter_keys_by_service` so the baseline matches each service.
 4. **Run evaluation** — `run_evaluation(output_root, inputs, run_name=...)`.
 5. **Inspect output** — load `evaluation_rows` from `scalars.json` (and optional `_service_summary`).
 
@@ -555,13 +555,13 @@ Pairing for distribution targets in this notebook: **ED current** uses **`admitt
 
 **`component` values in this notebook**:
 
-| `component`                                    | Charts / outputs                                                                                               |
-| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `classifier_model_diagnostics`                 | Headline metrics, feature importances, SHAP                                                                    |
-| `classifier_discrimination_madcap_calibration` | Discrimination, MADCAP, MADCAP-by-age, calibration                                                             |
-| `bed_demand_ed_current`                        | Per-service distribution comparison plot (EPUDD): ED-current bed-demand PMF vs recomputed observed count       |
-| `bed_demand_ed_yta`                            | Per-service distribution comparison plot (EPUDD): ED yet-to-arrive bed-demand PMF vs recomputed observed count |
-| `arrival_delta_cumulative`                     | Cumulative arrival delta PNG per service and prediction time                                                   |
+| `component`                                    | Charts / outputs                                                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `classifier_model_diagnostics`                 | Headline metrics, feature importances, SHAP                                                             |
+| `classifier_discrimination_madcap_calibration` | Discrimination, MADCAP, MADCAP-by-age, calibration                                                      |
+| `bed_demand_ed_current`                        | EPUDD plot; rPIT+CvM summary scalars (`rpit_cvm_mean_w2`, …); Binomial benchmark when cohort registered |
+| `bed_demand_ed_yta`                            | EPUDD plot; rPIT+CvM summary scalars only (no binomial benchmark for `arrived_in_window`)               |
+| `arrival_delta_cumulative`                     | Cumulative arrival delta PNG per service and prediction time                                            |
 
 ```python
 from pathlib import Path
@@ -729,17 +729,19 @@ builder.add_arrival_deltas(
 
     <patientflow.evaluate.inputs.EvaluationInputsBuilder at 0x315c382f0>
 
-### 3g. Build `EvaluationInputs`
+### 3g. Register benchmark cohort for rPIT + CvM
 
-**`build()`** checks that **`flow_selection`** and **`prediction_times`** are set, then returns the immutable object consumed by **`run_evaluation`**. The printout lists each target for a quick sanity check before the (longer) evaluation run.
+Distribution evaluation now writes **randomised PIT + Cramér–von Mises** summary scalars on each active service × prediction-time row when there are at least two snapshots with observations (`rpit_cvm_mean_w2`, `rpit_cvm_std_w2`, `rpit_cvm_n_observations`, …). EPUDD plots use the same minimum-snapshot gate.
+
+For **`admitted_at_some_point`** targets (ED current in this notebook), you can register a **Binomial(n, p̄)** benchmark: global class balance **p̄** per `prediction_time` on the full eval-split cohort, with **n** inferred from each snapshot PMF. That adds `rpit_cvm_benchmark_mean_w2` and `rpit_cvm_w2_reduction` on the same scalar rows. **Yet-to-arrive** (`arrived_in_window`) still gets rPIT+CvM but no binomial benchmark.
+
+Call **`add_distribution_benchmark_cohort`** once before **`build()`**, passing the same eval-split visit frame used for observation counts (here **`eval_visits_df`**).
 
 ```python
-inputs = builder.build()
-
-print(f"Targets: {len(evaluation_targets)}")
-for t in evaluation_targets:
-    print(f"  {t.flow_name}/{t.component}: {t.evaluation_mode} (observation_mode={t.observation_mode})")
-print(f"Prediction times: {prediction_times}")
+builder.add_distribution_benchmark_cohort(
+    admissions_ed_visits=eval_visits_df,
+    admissions_label_col="is_admitted",  # optional; default is "is_admitted"
+)
 
 ```
 
@@ -750,6 +752,19 @@ print(f"Prediction times: {prediction_times}")
       ed_yta_beds/bed_demand_ed_yta: distribution (observation_mode=arrived_in_window)
       ed_yta_arrival_rates/arrival_delta_cumulative: arrival_deltas (observation_mode=arrived_in_window)
     Prediction times: [(6, 0), (9, 30), (12, 0), (15, 30), (22, 0)]
+
+### 3h. Build `EvaluationInputs`
+
+**`build()`** checks that **`flow_selection`** and **`prediction_times`** are set, then returns the immutable object consumed by **`run_evaluation`**. The printout lists each target for a quick sanity check before the (longer) evaluation run.
+
+```python
+inputs = builder.build()
+
+print(f"Targets: {len(evaluation_targets)}")
+for t in evaluation_targets:
+    print(f"  {t.flow_name}/{t.component}: {t.evaluation_mode} (observation_mode={t.observation_mode})")
+print(f"Prediction times: {prediction_times}")
+```
 
 ## 4. Run evaluation
 
@@ -784,7 +799,9 @@ out
 
     ---------------------------------------------------------------------------
 
+
     KeyError                                  Traceback (most recent call last)
+
 
     Cell In[18], line 11
           3 from patientflow.evaluate.runner import run_evaluation
@@ -805,7 +822,7 @@ out
 
 ## 5. Review outputs
 
-Scalar rows are stored under the `evaluation_rows` key (with optional `_service_summary` for inactive-service bookkeeping). Below we print the run layout and show the first rows of the scalar table.
+Scalar rows are stored under the `evaluation_rows` key (with optional `_service_summary` for inactive-service bookkeeping). Distribution rows include **`rpit_cvm_mean_w2`** when a service × clock has at least two observed snapshots; **`rpit_cvm_benchmark_mean_w2`** and **`rpit_cvm_w2_reduction`** appear for **`bed_demand_ed_current`** when the benchmark cohort was registered. Below we print the run layout and show key columns from the scalar table.
 
 ```python
 import json
@@ -842,6 +859,10 @@ base_cols = [
         "prediction_time",
         "charts_generated",
         "skip_reason",
+        "rpit_cvm_mean_w2",
+        "rpit_cvm_benchmark_mean_w2",
+        "rpit_cvm_w2_reduction",
+        "rpit_cvm_n_observations",
     ]
     if c in scalars_df.columns
 ]
@@ -1045,8 +1066,8 @@ display(scalars_df[base_cols].head(16))
 ## Summary
 
 1. Built **service-level prediction dicts** with a **per-clock** nested layout for EPUDD (`get_model_key` as the middle key).
-2. Declared **`EvaluationTarget` instances** and wired **`EvaluationInputsBuilder`** with one **`flow_selection`** and **`eval_split`**, matching `flow_name` keys on targets to builder registrations.
-3. Ran **`run_evaluation`** to emit plots and **`scalars.json`**.
+2. Declared **`EvaluationTarget` instances** and wired **`EvaluationInputsBuilder`** with one **`flow_selection`** and **`eval_split`**, matching `flow_name` keys on targets to builder registrations, including **`add_distribution_benchmark_cohort`** for ED admissions.
+3. Ran **`run_evaluation`** to emit plots and **`scalars.json`** (including rPIT+CvM summary scalars on distribution rows).
 4. Loaded **`evaluation_rows`** for a tabular overview.
 
 For a wider evaluation matrix (inpatient departures by route, non-ED yet-to-arrive, survival), add **`EvaluationTarget`** rows and matching builder registrations—use distinct **`flow_name`** values per departures route (e.g. `departures_elective`) with **`component="departures_elective"`** (must match **`DEPARTURES_DISTRIBUTION_ADMISSION_TYPE`**), **`inpatient_visits_by_service`** on the shared snapshot frame, and route-specific PMFs.

--- a/notebooks/4c_Predict_demand.ipynb
+++ b/notebooks/4c_Predict_demand.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "# 4c. Predict emergency demand\n",
     "\n",
@@ -27,9 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Load data and prepare for model training\n",
     "\n",
@@ -160,9 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "The data has been prepared as a series of snapshots of each patient's data at five moments during the day. These five moments are the times when the bed managers wish to receive predictive models of emergency demand. If a patient arrives in the ED at 4 am, and leaves at 11 am, they will be represented in the 06:00 and 09:30 prediction times. Everything known about a patient up until that moment is included in that snapshot.\n",
     "\n",
@@ -233,9 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "\n",
     "## Train models\n",
@@ -345,9 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "\n",
     "The `SequenceToOutcomePredictor` is used to train the probability of each patient being admitted to a specialty, if admitted. As shown in the previous notebook, ordered sequences of consult requests (also known as referrals to service) are used to train this model. \n",
@@ -401,9 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Train models for patients yet to arrive\n",
     "\n",
@@ -454,9 +442,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## 1. Make predictions for the group of patients currently in the ED\n",
     "\n",
@@ -527,9 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "The predicted bed counts for patients in the ED take three probabilities into account for each patient snapshots: \n",
     "\n",
@@ -561,9 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "In the cell below I first calculate `prob_admission_in_window`, the probability of being admitted within the prediction window, given the elapsed time since each patient arrived, and the specified ED targets. \n",
     "\n",
@@ -624,9 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "With these probabilities prepared, I now iterate through the specialties to generate predictions for each in turn, and plot them in the charts shown."
    ]
@@ -731,9 +711,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## 2. Make predictions for patients yet-to-arrive to the ED who will need admission\n",
     "\n",
@@ -796,9 +774,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "##  3. Production prediction pipeline\n",
     "\n",
@@ -807,9 +783,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Use of `build_service_data` from the `predict.service` module\n",
     "\n",
@@ -876,9 +850,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "The returned object is a dictionary mapping each specialty to a `ServicePredictionInputs` instance (as introduced in [notebook 4a](4a_Organise_predictions_for_a_production_pipeline.ipynb)). Below I show the result for one specialty. The structure handles different types of flow, including elective inflows and discharges. It contains both inflows via the ED (used here), and (not used here) elective admissions, transfers and outflows. The latter show predictions of zero patients when no models are trained."
    ]
@@ -922,9 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "We now use `DemandPredictor` and `FlowSelection` (both introduced in [notebook 4a](4a_Organise_predictions_for_a_production_pipeline.ipynb)) to generate predictions from these inputs. Here I use `FlowSelection.custom()` to include only patients currently in the ED and exclude all other flows.\n",
     "\n",
@@ -963,9 +933,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "To view the constituent elements of the bundle, we can print it to get pretty output. A pmf range of 10 values is included in the printed output, centred around the mode. The output also records which flows were included. \n"
    ]
@@ -1000,9 +968,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "From the bundle, we can extract a probability distribution for the number of beds needed for patients currently in the ED. We can view the expectation, or view the percentiles of the distribution as shown below."
    ]
@@ -1040,9 +1006,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "To derive the yet-to-arrive predictions, we can set the FlowSelection accordingly. "
    ]
@@ -1153,9 +1117,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Summary\n",
     "\n",
@@ -1175,9 +1137,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "## Appendix: Legacy approaches (maintained for backward compatibility)\n",
     "\n",
@@ -1188,9 +1148,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Legacy `create_predictions` function with ED targets\n",
     "\n",
@@ -1242,9 +1200,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "### Alternative: using an empirical survival curve\n",
     "\n",
@@ -1326,9 +1282,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "`patientflow` includes a function to look up the probability of admission within a prediction window, using the survival curve. This is demonstrated below. It is used in the `create_predictions` function if the optional parameter `use_admission_in_window_prob` is set."
    ]
@@ -1367,9 +1321,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "For an array of patients, the probability of admission within the window would be created as shown below."
    ]
@@ -1402,9 +1354,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "Predictions are created using the legacy approach. \n"
    ]

--- a/notebooks/4d_Evaluate_demand_predictions.ipynb
+++ b/notebooks/4d_Evaluate_demand_predictions.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "1. **Load data** — same pattern as notebook 4c: `prepare_prediction_inputs`, temporal splits, synthetic `departure_datetime` on evaluation ED visits and inpatient arrivals where extracts omit those timestamps.\n",
     "2. **Demonstrate pairing** of observed values with predicted distributions, under different values of `observation_mode` \n",
-    "3. **Demonstrate the evaluate package** — `EvaluationInputsBuilder` with `flow_selection`, `prediction_times`, `eval_split`, and a custom `evaluation_targets` list whose `flow_name` keys match `add_classifier` / `add_distributions_*` / `add_arrival_deltas`. Distribution targets pair `add_distributions_from_service_dict` with `add_distribution_observations`. For arrival deltas with a multi-service predictor, pass `predictors_by_service` and `filter_keys_by_service` so the baseline matches each service.\n",
+    "3. **Demonstrate the evaluate package** — `EvaluationInputsBuilder` with `flow_selection`, `prediction_times`, `eval_split`, and a custom `evaluation_targets` list whose `flow_name` keys match `add_classifier` / `add_distributions_*` / `add_arrival_deltas`. Distribution targets pair `add_distributions_from_service_dict` with `add_distribution_observations`, and **`add_distribution_benchmark_cohort`** for the Binomial-benchmark on admission-style modes. For arrival deltas with a multi-service predictor, pass `predictors_by_service` and `filter_keys_by_service` so the baseline matches each service.\n",
     "4. **Run evaluation** — `run_evaluation(output_root, inputs, run_name=...)`.\n",
     "5. **Inspect output** — load `evaluation_rows` from `scalars.json` (and optional `_service_summary`).\n"
    ]
@@ -768,8 +768,8 @@
     "|-------------|------------------|\n",
     "| `classifier_model_diagnostics` | Headline metrics, feature importances, SHAP  |\n",
     "| `classifier_discrimination_madcap_calibration` | Discrimination, MADCAP, MADCAP-by-age, calibration  |\n",
-    "| `bed_demand_ed_current` | Per-service distribution comparison plot (EPUDD): ED-current bed-demand PMF vs recomputed observed count |\n",
-    "| `bed_demand_ed_yta` | Per-service distribution comparison plot (EPUDD): ED yet-to-arrive bed-demand PMF vs recomputed observed count |\n",
+    "| `bed_demand_ed_current` | EPUDD plot; rPIT+CvM summary scalars (`rpit_cvm_mean_w2`, …); Binomial benchmark when cohort registered |\n",
+    "| `bed_demand_ed_yta` | EPUDD plot; rPIT+CvM summary scalars only (no binomial benchmark for `arrived_in_window`) |\n",
     "| `arrival_delta_cumulative` | Cumulative arrival delta PNG per service and prediction time |\n"
    ]
   },
@@ -1070,9 +1070,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3g. Build `EvaluationInputs`\n",
+    "### 3g. Register benchmark cohort for rPIT + CvM\n",
     "\n",
-    "**`build()`** checks that **`flow_selection`** and **`prediction_times`** are set, then returns the immutable object consumed by **`run_evaluation`**. The printout lists each target for a quick sanity check before the (longer) evaluation run.\n"
+    "Distribution evaluation now writes **randomised PIT + Cramér–von Mises** summary scalars on each active service × prediction-time row when there are at least two snapshots with observations (`rpit_cvm_mean_w2`, `rpit_cvm_std_w2`, `rpit_cvm_n_observations`, …). EPUDD plots use the same minimum-snapshot gate.\n",
+    "\n",
+    "For **`admitted_at_some_point`** targets (ED current in this notebook), you can register a **Binomial(n, p̄)** benchmark: global class balance **p̄** per `prediction_time` on the full eval-split cohort, with **n** inferred from each snapshot PMF. That adds `rpit_cvm_benchmark_mean_w2` and `rpit_cvm_w2_reduction` on the same scalar rows. **Yet-to-arrive** (`arrived_in_window`) still gets rPIT+CvM but no binomial benchmark.\n",
+    "\n",
+    "Call **`add_distribution_benchmark_cohort`** once before **`build()`**, passing the same eval-split visit frame used for observation counts (here **`eval_visits_df`**).\n"
    ]
   },
   {
@@ -1102,12 +1106,33 @@
     }
    ],
    "source": [
+    "builder.add_distribution_benchmark_cohort(\n",
+    "    admissions_ed_visits=eval_visits_df,\n",
+    "    admissions_label_col=\"is_admitted\",  # optional; default is \"is_admitted\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3h. Build `EvaluationInputs`\n",
+    "\n",
+    "**`build()`** checks that **`flow_selection`** and **`prediction_times`** are set, then returns the immutable object consumed by **`run_evaluation`**. The printout lists each target for a quick sanity check before the (longer) evaluation run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "inputs = builder.build()\n",
     "\n",
     "print(f\"Targets: {len(evaluation_targets)}\")\n",
     "for t in evaluation_targets:\n",
     "    print(f\"  {t.flow_name}/{t.component}: {t.evaluation_mode} (observation_mode={t.observation_mode})\")\n",
-    "print(f\"Prediction times: {prediction_times}\")\n"
+    "print(f\"Prediction times: {prediction_times}\")"
    ]
   },
   {
@@ -1132,7 +1157,7 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "/Users/zellaking/miniconda3/envs/patientflow/lib/python3.13/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
@@ -1178,7 +1203,7 @@
    "source": [
     "## 5. Review outputs\n",
     "\n",
-    "Scalar rows are stored under the `evaluation_rows` key (with optional `_service_summary` for inactive-service bookkeeping). Below we print the run layout and show the first rows of the scalar table.\n"
+    "Scalar rows are stored under the `evaluation_rows` key (with optional `_service_summary` for inactive-service bookkeeping). Distribution rows include **`rpit_cvm_mean_w2`** when a service × clock has at least two observed snapshots; **`rpit_cvm_benchmark_mean_w2`** and **`rpit_cvm_w2_reduction`** appear for **`bed_demand_ed_current`** when the benchmark cohort was registered. Below we print the run layout and show key columns from the scalar table.\n"
    ]
   },
   {
@@ -1488,6 +1513,10 @@
     "        \"prediction_time\",\n",
     "        \"charts_generated\",\n",
     "        \"skip_reason\",\n",
+    "        \"rpit_cvm_mean_w2\",\n",
+    "        \"rpit_cvm_benchmark_mean_w2\",\n",
+    "        \"rpit_cvm_w2_reduction\",\n",
+    "        \"rpit_cvm_n_observations\",\n",
     "    ]\n",
     "    if c in scalars_df.columns\n",
     "]\n",
@@ -1501,8 +1530,8 @@
     "## Summary\n",
     "\n",
     "1. Built **service-level prediction dicts** with a **per-clock** nested layout for EPUDD (`get_model_key` as the middle key).\n",
-    "2. Declared **`EvaluationTarget` instances** and wired **`EvaluationInputsBuilder`** with one **`flow_selection`** and **`eval_split`**, matching `flow_name` keys on targets to builder registrations.\n",
-    "3. Ran **`run_evaluation`** to emit plots and **`scalars.json`**.\n",
+    "2. Declared **`EvaluationTarget` instances** and wired **`EvaluationInputsBuilder`** with one **`flow_selection`** and **`eval_split`**, matching `flow_name` keys on targets to builder registrations, including **`add_distribution_benchmark_cohort`** for ED admissions.\n",
+    "3. Ran **`run_evaluation`** to emit plots and **`scalars.json`** (including rPIT+CvM summary scalars on distribution rows).\n",
     "4. Loaded **`evaluation_rows`** for a tabular overview.\n",
     "\n",
     "For a wider evaluation matrix (inpatient departures by route, non-ED yet-to-arrive, survival), add **`EvaluationTarget`** rows and matching builder registrations—use distinct **`flow_name`** values per departures route (e.g. `departures_elective`) with **`component=\"departures_elective\"`** (must match **`DEPARTURES_DISTRIBUTION_ADMISSION_TYPE`**), **`inpatient_visits_by_service`** on the shared snapshot frame, and route-specific PMFs.\n"

--- a/src/patientflow/evaluate/calibration.py
+++ b/src/patientflow/evaluate/calibration.py
@@ -1,0 +1,205 @@
+"""Randomised PIT + Cramér–von Mises calibration for discrete predictive distributions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy.stats import binom, cramervonmises
+
+from patientflow.evaluate.distributions import (
+    cdf_from_agg_predicted,
+    proba_array_from_agg_predicted,
+)
+
+MIN_DISTRIBUTION_SNAPSHOTS = 2
+DEFAULT_RPIT_REPETITIONS = 500
+
+BenchmarkCohortKey = str  # "admissions" | "departures"
+
+
+@dataclass(frozen=True)
+class BenchmarkCohortSpec:
+    """Eval-split cohort used to compute global p̄ per prediction clock."""
+
+    visits_df: pd.DataFrame
+    label_col: str
+    prediction_time_col: str = "prediction_time"
+
+
+@dataclass(frozen=True)
+class RpitCvmResult:
+    """Summary of rPIT + CvM calibration for one model on one prob_dist_dict slice."""
+
+    mean_w2: float
+    w2_values: List[float]
+    std_w2: float
+    n_observations: int
+    n_repetitions: int
+
+
+def benchmark_cohort_key_for_observation_mode(
+    observation_mode: str,
+) -> Optional[BenchmarkCohortKey]:
+    """Return benchmark cohort key for *observation_mode*, or None if no binomial benchmark."""
+    if observation_mode in ("admitted_at_some_point", "admitted_in_window"):
+        return "admissions"
+    if observation_mode == "departed_in_window":
+        return "departures"
+    return None
+
+
+def global_p_bar_by_prediction_time(
+    visits_df: pd.DataFrame,
+    prediction_times: Sequence[Tuple[int, int]],
+    *,
+    label_col: str,
+    prediction_time_col: str = "prediction_time",
+) -> Dict[Tuple[int, int], float]:
+    """Global class balance per prediction clock on the eval-split cohort."""
+    if label_col not in visits_df.columns:
+        raise ValueError(
+            f"benchmark cohort requires column {label_col!r} on visits dataframe"
+        )
+    if prediction_time_col not in visits_df.columns:
+        raise ValueError(
+            f"benchmark cohort requires column {prediction_time_col!r} on visits dataframe"
+        )
+
+    out: Dict[Tuple[int, int], float] = {}
+    labels = visits_df[label_col].astype(bool)
+    for pt in prediction_times:
+        mask = visits_df[prediction_time_col] == pt
+        sub = labels[mask]
+        if len(sub) == 0:
+            out[pt] = 0.0
+        else:
+            out[pt] = float(sub.mean())
+    return out
+
+
+def binomial_pmf_from_n_p(
+    n: int,
+    p_bar: float,
+    *,
+    max_k: Optional[int] = None,
+) -> np.ndarray:
+    """Probability mass on ``0..max_k`` for ``Binomial(n, p_bar)``."""
+    n = max(0, int(n))
+    p_bar = float(np.clip(p_bar, 0.0, 1.0))
+    upper = int(max_k if max_k is not None else n)
+    upper = max(upper, n)
+    support = np.arange(0, upper + 1, dtype=int)
+    return np.asarray(binom.pmf(support, n, p_bar), dtype=float)
+
+
+def cohort_size_from_leaf(leaf: Mapping[str, Any]) -> int:
+    """Infer trial count *n* from patientflow PMF support (length − 1)."""
+    proba = proba_array_from_agg_predicted(leaf.get("agg_predicted"))
+    return max(0, len(proba) - 1)
+
+
+def build_benchmark_prob_dist_dict(
+    patientflow_prob_dist_dict: Mapping[Any, Mapping[str, Any]],
+    *,
+    p_bar: float,
+) -> Dict[Any, Dict[str, Any]]:
+    """Mirror snapshot keys with ``Binomial(n, p_bar)`` PMFs; copy ``agg_observed``."""
+    out: Dict[Any, Dict[str, Any]] = {}
+    for snap, leaf in patientflow_prob_dist_dict.items():
+        if not isinstance(leaf, Mapping):
+            continue
+        n = cohort_size_from_leaf(leaf)
+        proba = binomial_pmf_from_n_p(n, p_bar, max_k=n)
+        out[snap] = {
+            "agg_predicted": {"agg_proba": proba},
+            "agg_observed": leaf.get("agg_observed", 0),
+        }
+    return out
+
+
+def _iter_valid_leaves(
+    prob_dist_dict: Mapping[Any, Mapping[str, Any]],
+) -> List[Tuple[int, Callable[[float], float]]]:
+    pairs: List[Tuple[int, Callable[[float], float]]] = []
+    for _snap, leaf in prob_dist_dict.items():
+        if not isinstance(leaf, Mapping):
+            continue
+        if "agg_predicted" not in leaf:
+            continue
+        try:
+            x = int(leaf.get("agg_observed", 0) or 0)
+            cdf = cdf_from_agg_predicted(leaf["agg_predicted"])
+        except (TypeError, ValueError):
+            continue
+        pairs.append((x, cdf))
+    return pairs
+
+
+def _rpit_draws(
+    observations: Sequence[int],
+    cdfs: Sequence[Callable[[float], float]],
+    rng: np.random.Generator,
+) -> np.ndarray:
+    u = np.empty(len(observations), dtype=float)
+    for i, (x, cdf) in enumerate(zip(observations, cdfs)):
+        p_lo = cdf(float(x - 1)) if x > 0 else 0.0
+        p_hi = cdf(float(x))
+        if p_hi <= p_lo:
+            u[i] = p_lo
+        else:
+            u[i] = rng.uniform(p_lo, p_hi)
+    return u
+
+
+def cramervonmises_w2_uniform(u: np.ndarray) -> float:
+    """One-sample CvM W² against Uniform(0, 1)."""
+    return float(cramervonmises(np.asarray(u, dtype=float), cdf="uniform").statistic)
+
+
+def rpit_cvm_calibration_score(
+    prob_dist_dict: Mapping[Any, Mapping[str, Any]],
+    *,
+    n_repetitions: int = DEFAULT_RPIT_REPETITIONS,
+    seed: Optional[int] = None,
+) -> Optional[RpitCvmResult]:
+    """Run rPIT + CvM; return None if fewer than two valid snapshot leaves."""
+    pairs = _iter_valid_leaves(prob_dist_dict)
+    n_obs = len(pairs)
+    if n_obs < MIN_DISTRIBUTION_SNAPSHOTS:
+        return None
+
+    observations = [p[0] for p in pairs]
+    cdfs = [p[1] for p in pairs]
+    rng = np.random.default_rng(seed)
+    w2_values: List[float] = []
+    for _ in range(n_repetitions):
+        u = _rpit_draws(observations, cdfs, rng)
+        w2_values.append(cramervonmises_w2_uniform(u))
+
+    arr = np.asarray(w2_values, dtype=float)
+    return RpitCvmResult(
+        mean_w2=float(arr.mean()),
+        w2_values=w2_values,
+        std_w2=float(arr.std(ddof=0)),
+        n_observations=n_obs,
+        n_repetitions=n_repetitions,
+    )
+
+
+def rpit_cvm_result_to_scalar_fields(
+    result: RpitCvmResult,
+    *,
+    prefix: str = "rpit_cvm",
+    seed: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Map ``RpitCvmResult`` to scalar row fields with a given key prefix."""
+    return {
+        f"{prefix}_mean_w2": result.mean_w2,
+        f"{prefix}_std_w2": result.std_w2,
+        f"{prefix}_n_observations": result.n_observations,
+        f"{prefix}_n_repetitions": result.n_repetitions,
+        f"{prefix}_seed": seed,
+    }

--- a/src/patientflow/evaluate/distributions.py
+++ b/src/patientflow/evaluate/distributions.py
@@ -1,0 +1,86 @@
+"""Discrete distribution helpers shared by evaluate calibration and viz."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Union
+
+import numpy as np
+import pandas as pd
+
+
+def proba_array_from_agg_predicted(agg_predicted: Any) -> np.ndarray:
+    """Return a 1-D probability mass array from an ``agg_predicted`` payload."""
+    if isinstance(agg_predicted, dict) and "agg_proba" in agg_predicted:
+        return np.asarray(agg_predicted["agg_proba"], dtype=float).flatten()
+    if isinstance(agg_predicted, pd.DataFrame) and "agg_proba" in agg_predicted.columns:
+        return np.asarray(agg_predicted["agg_proba"].to_numpy(), dtype=float).flatten()
+    if isinstance(agg_predicted, pd.Series):
+        return np.asarray(agg_predicted.values, dtype=float).flatten()
+    raise TypeError(
+        "agg_predicted must be a dict with 'agg_proba', a DataFrame with "
+        "'agg_proba', or a Series"
+    )
+
+
+def cdf_from_proba_array(proba: np.ndarray) -> Callable[[float], float]:
+    """Build a discrete CDF callable ``F(k) = P(X <= k)`` from a PMF array."""
+    p = np.asarray(proba, dtype=float).flatten()
+    if p.size == 0:
+        return lambda x: 0.0
+    cum = np.cumsum(p)
+    values = np.arange(len(p))
+
+    def cdf(x: float) -> float:
+        if x < values[0]:
+            return 0.0
+        idx = int(np.floor(x))
+        if idx >= len(cum):
+            return float(cum[-1])
+        return float(cum[idx])
+
+    return cdf
+
+
+def cdf_from_agg_predicted(agg_predicted: Any) -> Callable[[float], float]:
+    """Build a CDF callable from an ``agg_predicted`` leaf field."""
+    return cdf_from_proba_array(proba_array_from_agg_predicted(agg_predicted))
+
+
+def prob_to_cdf(
+    prob_dist: Union[pd.Series, pd.DataFrame, Dict, np.ndarray],
+) -> Callable[[float], float]:
+    """Convert a probability distribution to a CDF function (viz-compatible API)."""
+    import pandas as pd
+
+    if isinstance(prob_dist, pd.DataFrame):
+        if len(prob_dist) > 0:
+            prob_series = prob_dist.iloc[0]
+        else:
+            raise ValueError("Empty DataFrame provided")
+        values = list(prob_series.index)
+        probs = list(prob_series.values)
+    elif isinstance(prob_dist, pd.Series):
+        values = list(prob_dist.index)
+        probs = list(prob_dist.values)
+    elif isinstance(prob_dist, dict):
+        sorted_items = sorted(prob_dist.items())
+        values = [item[0] for item in sorted_items]
+        probs = [item[1] for item in sorted_items]
+    else:
+        values = list(range(len(prob_dist)))
+        probs = list(prob_dist)
+
+    sorted_pairs = sorted(zip(values, probs))
+    vals = [pair[0] for pair in sorted_pairs]
+    probs_sorted = [pair[1] for pair in sorted_pairs]
+    cum_probs = np.cumsum(probs_sorted)
+
+    def cdf_function(x: float) -> float:
+        if x < vals[0]:
+            return 0.0
+        for i, val in enumerate(vals):
+            if x <= val:
+                return float(cum_probs[i])
+        return 1.0
+
+    return cdf_function

--- a/src/patientflow/evaluate/handlers.py
+++ b/src/patientflow/evaluate/handlers.py
@@ -22,6 +22,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from patientflow.evaluate.calibration import (
+    MIN_DISTRIBUTION_SNAPSHOTS,
+    benchmark_cohort_key_for_observation_mode,
+    build_benchmark_prob_dist_dict,
+    global_p_bar_by_prediction_time,
+    rpit_cvm_calibration_score,
+    rpit_cvm_result_to_scalar_fields,
+)
 from patientflow.evaluate.inputs import (
     EvaluationInputs,
     EvaluationTarget,
@@ -32,12 +40,14 @@ from patientflow.evaluate.observations import (
     admission_type_filter_for_distribution_component,
     count_observed,
     count_observed_applies_specialty_filter,
+    count_observed_label_kwargs,
     observation_context_frame_key,
 )
 from patientflow.evaluate.scalars import (
     SERVICE_SENTINEL_ALL,
     ScalarsCollector,
     classifier_reliable,
+    scalar_target_fields,
 )
 from patientflow.load import get_model_key
 from patientflow.model_artifacts import TrainedClassifier
@@ -295,9 +305,7 @@ def _classifier_diagnostics_scalar_row(
     reliable = classifier_reliable(metrics, pos_cases)
     hour, minute = pt
     return {
-        "evaluation_mode": target.evaluation_mode,
-        "flow": target.flow_name,
-        "flow_type": target.flow_type,
+        **scalar_target_fields(target),
         "service": SERVICE_SENTINEL_ALL,
         "component": target.component,
         "prediction_time": [hour, minute],
@@ -486,6 +494,7 @@ def _recompute_leaf_agg_observed(
     prediction_time: Tuple[int, int],
     prediction_window: timedelta,
     observation_frame: pd.DataFrame,
+    benchmark_cohorts: Mapping[str, Mapping[str, Any]],
 ) -> None:
     """Recompute and set `agg_observed` on one distribution leaf."""
     frame_key = observation_context_frame_key(target.observation_mode)
@@ -493,6 +502,7 @@ def _recompute_leaf_agg_observed(
         "snapshot_date": snapshot_date,
         "prediction_time": prediction_time,
         "prediction_window": prediction_window,
+        **count_observed_label_kwargs(target.observation_mode, benchmark_cohorts),
     }
     if count_observed_applies_specialty_filter(target.observation_mode):
         count_kwargs["specialty"] = str(service)
@@ -526,6 +536,7 @@ def _recompute_distribution_observed_counts(
     model_name: str,
     prediction_dict: Mapping[Tuple[int, int], timedelta],
     observation_frame: pd.DataFrame,
+    benchmark_cohorts: Mapping[str, Mapping[str, Any]],
 ) -> None:
     """Update `agg_observed` on every leaf in a per-service distribution tree."""
     prediction_times = prediction_times_from_dict(prediction_dict)
@@ -548,6 +559,7 @@ def _recompute_distribution_observed_counts(
                     prediction_time=pt,
                     prediction_window=prediction_dict[pt],
                     observation_frame=observation_frame,
+                    benchmark_cohorts=benchmark_cohorts,
                 )
         return
 
@@ -567,6 +579,7 @@ def _recompute_distribution_observed_counts(
                 prediction_time=pt,
                 prediction_window=prediction_dict[pt],
                 observation_frame=observation_frame,
+                benchmark_cohorts=benchmark_cohorts,
             )
 
 
@@ -854,15 +867,35 @@ def evaluate_classifier_probability_quality(
 
     collector.add_row(
         {
-            "evaluation_mode": target.evaluation_mode,
-            "flow": target.flow_name,
-            "flow_type": target.flow_type,
+            **scalar_target_fields(target),
             "service": SERVICE_SENTINEL_ALL,
             "component": target.component,
             "prediction_time": None,
             "model_name": "",
             "charts_generated": True,
         }
+    )
+
+
+def _benchmark_p_bar_by_prediction_time(
+    inputs: EvaluationInputs,
+    target: EvaluationTarget,
+) -> Optional[Dict[Tuple[int, int], float]]:
+    """Global p̄ per clock when observation mode supports a binomial benchmark."""
+    cohort_key = benchmark_cohort_key_for_observation_mode(target.observation_mode)
+    if cohort_key is None:
+        return None
+    spec = inputs.distribution_benchmark_cohorts.get(cohort_key)
+    if not spec:
+        return None
+    visits_df = spec.get("visits_df")
+    label_col = spec.get("label_col")
+    if visits_df is None or label_col is None:
+        return None
+    return global_p_bar_by_prediction_time(
+        visits_df,
+        inputs.prediction_times,
+        label_col=str(label_col),
     )
 
 
@@ -873,7 +906,7 @@ def evaluate_distribution(
     distributions_dir: Path,
     collector: ScalarsCollector,
 ) -> None:
-    """Plot EPUDD per active service and record per-time snapshot counts.
+    """Plot EPUDD and rPIT+CvM calibration per active service and prediction time.
 
     Parameters
     ----------
@@ -889,11 +922,13 @@ def evaluate_distribution(
 
     Notes
     -----
-    Inactive services (no observed mass and negligible predicted mass) skip charts
-    and emit `skip_reason: inactive_service` rows. Recomputes `agg_observed` on
-    each leaf from `observation_contexts` and `target.observation_mode` before
-    plotting (asserts if a pre-set `agg_observed` disagrees). Uses
-    `patientflow.viz.epudd.plot_epudd`.
+    Inactive services skip evaluation (`skip_reason: inactive_service`).
+    Active services with fewer than ``MIN_DISTRIBUTION_SNAPSHOTS`` snapshot
+    leaves per clock skip EPUDD and calibration
+    (`skip_reason: insufficient_observations`). Binomial benchmark scalars are
+    emitted only when ``observation_mode`` supports a benchmark cohort and
+    ``add_distribution_benchmark_cohort`` registered the matching eval-split
+    frame (not for yet-to-arrive ``arrived_in_window`` modes).
     """
     block = inputs.distribution_by_flow.get(target.flow_name)
     if not block:
@@ -901,6 +936,7 @@ def evaluate_distribution(
     prob_by_svc: Mapping[str, Any] = block.get("prob_dist_by_service") or {}
     model_name: str = str(block.get("model_name") or "admissions")
     prediction_dict = inputs.prediction_dict
+    p_bar_by_pt = _benchmark_p_bar_by_prediction_time(inputs, target)
     if not prob_by_svc:
         collector.merge_service_summary_slice(
             f"{target.evaluation_mode}/{target.flow_name}/{target.component}",
@@ -908,6 +944,7 @@ def evaluate_distribution(
                 "mode": "distribution",
                 "flow": target.flow_name,
                 "component": target.component,
+                "observation_mode": target.observation_mode,
                 "n_active_services": 0,
                 "n_inactive_services": 0,
                 "inactive_service_names": [],
@@ -932,6 +969,7 @@ def evaluate_distribution(
             model_name=model_name,
             prediction_dict=prediction_dict,
             observation_frame=observation_frame,
+            benchmark_cohorts=inputs.distribution_benchmark_cohorts,
         )
         inactive = _service_is_inactive_distribution(
             per_date,
@@ -948,9 +986,7 @@ def evaluate_distribution(
                 h, mi = pt
                 collector.add_row(
                     {
-                        "evaluation_mode": target.evaluation_mode,
-                        "flow": target.flow_name,
-                        "flow_type": target.flow_type,
+                        **scalar_target_fields(target),
                         "service": str(service),
                         "component": target.component,
                         "prediction_time": [h, mi],
@@ -967,43 +1003,87 @@ def evaluate_distribution(
         prob_all = _build_prob_dist_dict_all_for_service(
             per_date, model_name, inputs.prediction_times
         )
+        epudd_times = [
+            pt
+            for pt in inputs.prediction_times
+            if len(prob_all.get(get_model_key(model_name, pt)) or {})
+            >= MIN_DISTRIBUTION_SNAPSHOTS
+        ]
         svc_dir = distributions_dir / target.flow_name / _safe_fs_segment(str(service))
         svc_dir.mkdir(parents=True, exist_ok=True)
-        fig = plot_epudd(
-            list(inputs.prediction_times),
-            prob_all,
-            model_name=model_name,
-            return_figure=True,
-            media_file_path=svc_dir,
-            file_name=f"{target.component}.png",
-            suptitle=_distribution_comparison_suptitle(
-                target, str(service), eval_split=inputs.eval_split
-            ),
-        )
-        if fig is not None:
-            plt.close(fig)
-        else:
-            plt.close("all")
+        if epudd_times:
+            fig = plot_epudd(
+                epudd_times,
+                prob_all,
+                model_name=model_name,
+                return_figure=True,
+                media_file_path=svc_dir,
+                file_name=f"{target.component}.png",
+                suptitle=_distribution_comparison_suptitle(
+                    target, str(service), eval_split=inputs.eval_split
+                ),
+            )
+            if fig is not None:
+                plt.close(fig)
+            else:
+                plt.close("all")
 
         for pt in inputs.prediction_times:
             h, mi = pt
             mk = get_model_key(model_name, pt)
             series_dict = prob_all.get(mk) or {}
             n_snap = len(series_dict)
-            collector.add_row(
-                {
-                    "evaluation_mode": target.evaluation_mode,
-                    "flow": target.flow_name,
-                    "flow_type": target.flow_type,
-                    "service": str(service),
-                    "component": target.component,
-                    "prediction_time": [h, mi],
-                    "model_name": model_name,
-                    "charts_generated": True,
-                    "n_snapshots": n_snap,
-                    "reliable": n_snap > 0,
-                }
-            )
+            base_row: Dict[str, Any] = {
+                **scalar_target_fields(target),
+                "service": str(service),
+                "component": target.component,
+                "prediction_time": [h, mi],
+                "model_name": model_name,
+                "n_snapshots": n_snap,
+            }
+            if n_snap < MIN_DISTRIBUTION_SNAPSHOTS:
+                collector.add_row(
+                    {
+                        **base_row,
+                        "charts_generated": False,
+                        "skip_reason": "insufficient_observations",
+                        "reliable": False,
+                    }
+                )
+                continue
+
+            pf_result = rpit_cvm_calibration_score(series_dict)
+            row: Dict[str, Any] = {
+                **base_row,
+                "charts_generated": True,
+                "reliable": True,
+            }
+            if pf_result is not None:
+                row.update(rpit_cvm_result_to_scalar_fields(pf_result, seed=None))
+
+            if p_bar_by_pt is not None:
+                p_bar = p_bar_by_pt.get(pt)
+                if p_bar is not None:
+                    bench_dict = build_benchmark_prob_dist_dict(
+                        series_dict, p_bar=p_bar
+                    )
+                    bm_result = rpit_cvm_calibration_score(bench_dict)
+                    if bm_result is not None and pf_result is not None:
+                        row.update(
+                            rpit_cvm_result_to_scalar_fields(
+                                bm_result, prefix="rpit_cvm_benchmark", seed=None
+                            )
+                        )
+                        row.update(
+                            {
+                                "rpit_cvm_w2_reduction": (
+                                    bm_result.mean_w2 - pf_result.mean_w2
+                                ),
+                                "rpit_cvm_benchmark_p_bar": p_bar,
+                            }
+                        )
+
+            collector.add_row(row)
 
     collector.merge_service_summary_slice(
         f"{target.evaluation_mode}/{target.flow_name}/{target.component}",
@@ -1011,6 +1091,7 @@ def evaluate_distribution(
             "mode": "distribution",
             "flow": target.flow_name,
             "component": target.component,
+            "observation_mode": target.observation_mode,
             "n_active_services": active_count,
             "n_inactive_services": len(inactive_names),
             "inactive_service_names": inactive_names,
@@ -1066,9 +1147,7 @@ def evaluate_arrival_deltas(
                 h, mi = pt
                 collector.add_row(
                     {
-                        "evaluation_mode": target.evaluation_mode,
-                        "flow": target.flow_name,
-                        "flow_type": target.flow_type,
+                        **scalar_target_fields(target),
                         "service": str(svc),
                         "component": target.component,
                         "prediction_time": [h, mi],
@@ -1111,9 +1190,7 @@ def evaluate_arrival_deltas(
             plt.close("all")
             collector.add_row(
                 {
-                    "evaluation_mode": target.evaluation_mode,
-                    "flow": target.flow_name,
-                    "flow_type": target.flow_type,
+                    **scalar_target_fields(target),
                     "service": str(svc),
                     "component": target.component,
                     "prediction_time": [h, mi],
@@ -1129,6 +1206,7 @@ def evaluate_arrival_deltas(
             "mode": "arrival_deltas",
             "flow": target.flow_name,
             "component": target.component,
+            "observation_mode": target.observation_mode,
             "n_active_services": active,
             "n_inactive_services": len(inactive_names),
             "inactive_service_names": inactive_names,
@@ -1180,9 +1258,7 @@ def evaluate_survival_curve(
     plt.close("all")
     collector.add_row(
         {
-            "evaluation_mode": target.evaluation_mode,
-            "flow": target.flow_name,
-            "flow_type": target.flow_type,
+            **scalar_target_fields(target),
             "service": SERVICE_SENTINEL_ALL,
             "component": target.component,
             "prediction_time": None,

--- a/src/patientflow/evaluate/inputs.py
+++ b/src/patientflow/evaluate/inputs.py
@@ -37,7 +37,11 @@ from typing import (
 
 import pandas as pd
 
-from patientflow.evaluate.observations import OBSERVATION_MODES
+from patientflow.evaluate.observations import (
+    DEFAULT_ADMISSION_LABEL_COL,
+    DEFAULT_DEPARTURE_OUTCOME_COLUMN,
+    OBSERVATION_MODES,
+)
 from patientflow.model_artifacts import TrainedClassifier
 from patientflow.predict.types import FlowSelection
 
@@ -222,6 +226,9 @@ class EvaluationInputs:
         When set, keys include `train_df`, `test_df`, column names, `labels`.
     observation_contexts : dict
         `flow_name` → `service` → visit frames for observation counting.
+    distribution_benchmark_cohorts : dict
+        Optional ``"admissions"`` / ``"departures"`` cohorts for global p̄
+        (see `add_distribution_benchmark_cohort`).
     eval_split : str
         Holdout assessed by this run: ``"valid"`` (default) or ``"test"``.
         Drives plot cohort labels; visit frames and snapshot dates must match.
@@ -237,6 +244,9 @@ class EvaluationInputs:
     arrival_by_flow: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     survival: Optional[Dict[str, Any]] = None
     observation_contexts: Dict[str, Dict[str, Dict[str, Any]]] = field(
+        default_factory=dict
+    )
+    distribution_benchmark_cohorts: Dict[str, Dict[str, Any]] = field(
         default_factory=dict
     )
 
@@ -283,6 +293,7 @@ class EvaluationInputsBuilder:
         self._arrival_by_flow: Dict[str, Dict[str, Any]] = {}
         self._survival: Optional[Dict[str, Any]] = None
         self._observation_contexts: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        self._distribution_benchmark_cohorts: Dict[str, Dict[str, Any]] = {}
 
     def set_flow_selection(
         self, flow_selection: FlowSelection
@@ -532,6 +543,53 @@ class EvaluationInputsBuilder:
         _register(inpatient_visits_by_service, "inpatient_visits")
         return self
 
+    def add_distribution_benchmark_cohort(
+        self,
+        *,
+        admissions_ed_visits: Optional[pd.DataFrame] = None,
+        admissions_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
+        departures_inpatient_visits: Optional[pd.DataFrame] = None,
+        departures_label_col: str = DEFAULT_DEPARTURE_OUTCOME_COLUMN,
+    ) -> EvaluationInputsBuilder:
+        """Register eval-split cohorts for global binomial-benchmark p̄.
+
+        The same label columns are used when distribution evaluation recomputes
+        ``agg_observed`` (via :func:`count_observed`) and for benchmark p̄.
+
+        Parameters
+        ----------
+        admissions_ed_visits : pandas.DataFrame, optional
+            Full eval-split ED visits with *admissions_label_col* and
+            ``prediction_time``. Used when ``observation_mode`` is
+            ``admitted_at_some_point`` or ``admitted_in_window``.
+        admissions_label_col : str, optional
+            Boolean admission label on *admissions_ed_visits*. Default
+            ``"is_admitted"``.
+        departures_inpatient_visits : pandas.DataFrame, optional
+            Full eval-split inpatient snapshots with *departures_label_col* and
+            ``prediction_time``. Used when ``observation_mode`` is
+            ``departed_in_window``.
+        departures_label_col : str, optional
+            Boolean departure label on *departures_inpatient_visits*. Default
+            ``"left_subspecialty_in_window"``.
+
+        Returns
+        -------
+        EvaluationInputsBuilder
+            ``self`` for method chaining.
+        """
+        if admissions_ed_visits is not None:
+            self._distribution_benchmark_cohorts["admissions"] = {
+                "visits_df": admissions_ed_visits,
+                "label_col": admissions_label_col,
+            }
+        if departures_inpatient_visits is not None:
+            self._distribution_benchmark_cohorts["departures"] = {
+                "visits_df": departures_inpatient_visits,
+                "label_col": departures_label_col,
+            }
+        return self
+
     def add_arrival_deltas(
         self,
         flow_name: str,
@@ -667,4 +725,5 @@ class EvaluationInputsBuilder:
                 fn: {svc: dict(ctx) for svc, ctx in per.items()}
                 for fn, per in self._observation_contexts.items()
             },
+            distribution_benchmark_cohorts=dict(self._distribution_benchmark_cohorts),
         )

--- a/src/patientflow/evaluate/observations.py
+++ b/src/patientflow/evaluate/observations.py
@@ -46,7 +46,7 @@ departed_in_window
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Optional, Tuple
+from typing import Any, Mapping, Optional, Tuple
 
 import pandas as pd
 
@@ -57,6 +57,9 @@ OBSERVATION_MODES: tuple[str, ...] = (
     "arrived_in_window",
     "arrived_and_admitted_in_window",
 )  #: Allowed observation_mode strings accepted by count_observed.
+
+DEFAULT_ADMISSION_LABEL_COL = "is_admitted"
+DEFAULT_DEPARTURE_OUTCOME_COLUMN = "left_subspecialty_in_window"
 
 # Context keys on ``EvaluationInputs.observation_contexts[flow][service]``.
 OBSERVATION_CONTEXT_FRAME_KEYS: dict[str, str] = {
@@ -76,6 +79,29 @@ DEPARTURES_DISTRIBUTION_ADMISSION_TYPE: dict[str, str] = {
 
 _ARRIVAL_OBSERVATION_MODES = frozenset({"admitted_at_some_point", "admitted_in_window"})
 _DEPARTURE_OBSERVATION_MODES = frozenset({"departed_in_window"})
+
+
+def count_observed_label_kwargs(
+    observation_mode: str,
+    benchmark_cohorts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, str]:
+    """Return ``admission_label_col`` / ``outcome_column`` for ``count_observed``.
+
+    Uses ``benchmark_cohorts`` from ``EvaluationInputs.distribution_benchmark_cohorts``
+    when registered via ``add_distribution_benchmark_cohort``; otherwise defaults.
+    """
+    kwargs: dict[str, str] = {}
+    if observation_mode in ("admitted_at_some_point", "admitted_in_window"):
+        spec = benchmark_cohorts.get("admissions") or {}
+        kwargs["admission_label_col"] = str(
+            spec.get("label_col", DEFAULT_ADMISSION_LABEL_COL)
+        )
+    elif observation_mode == "departed_in_window":
+        spec = benchmark_cohorts.get("departures") or {}
+        kwargs["outcome_column"] = str(
+            spec.get("label_col", DEFAULT_DEPARTURE_OUTCOME_COLUMN)
+        )
+    return kwargs
 
 
 def _prediction_moment(
@@ -99,8 +125,9 @@ def count_observed_admitted_at_some_point(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    admission_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
 ) -> int:
-    """Count ED snapshot rows with `is_admitted` for the prediction moment.
+    """Count ED snapshot rows with a true admission label for the prediction moment.
 
     The prediction window is accepted for API compatibility with other
     strategies but does not affect the count: the cohort is the snapshot at
@@ -110,7 +137,9 @@ def count_observed_admitted_at_some_point(
     ----------
     ed_visits : pandas.DataFrame
         ED visits with columns *snapshot_date*, *prediction_time*,
-        *is_admitted*, and *specialty* when *specialty* is not None.
+        *admission_label_col*, and *specialty* when *specialty* is not None.
+    admission_label_col : str, optional
+        Boolean admission label column. Default is ``DEFAULT_ADMISSION_LABEL_COL``.
     snapshot_date : datetime.date
         Snapshot calendar date.
     prediction_time : tuple of (int, int)
@@ -126,10 +155,14 @@ def count_observed_admitted_at_some_point(
         Number of matching admitted rows.
     """
     del prediction_window  # retained for signature compatibility
+    if admission_label_col not in ed_visits.columns:
+        raise ValueError(
+            f"admitted_at_some_point requires column {admission_label_col!r} on ed_visits"
+        )
     mask = (
         (ed_visits["snapshot_date"] == snapshot_date)
         & (ed_visits["prediction_time"] == prediction_time)
-        & (ed_visits["is_admitted"].astype(bool))
+        & (ed_visits[admission_label_col].astype(bool))
     )
     if specialty is not None:
         mask = mask & (ed_visits["specialty"] == specialty)
@@ -143,6 +176,7 @@ def count_observed_admitted_in_window(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    admission_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
     departure_datetime_col: str = "departure_datetime",
 ) -> int:
     """Count snapshot-cohort ED rows admitted with leave-ED time in the window.
@@ -161,7 +195,9 @@ def count_observed_admitted_in_window(
     ----------
     ed_visits : pandas.DataFrame
         Must include *departure_datetime_col*, *snapshot_date*, *prediction_time*,
-        *is_admitted*, and *specialty* if *specialty* is set.
+        *admission_label_col*, and *specialty* if *specialty* is set.
+    admission_label_col : str, optional
+        Boolean admission label column. Default is ``DEFAULT_ADMISSION_LABEL_COL``.
     snapshot_date : datetime.date
         Snapshot calendar date.
     prediction_time : tuple of (int, int)
@@ -189,13 +225,17 @@ def count_observed_admitted_in_window(
         raise ValueError(
             f"admitted_in_window requires column {departure_datetime_col!r} on ed_visits"
         )
+    if admission_label_col not in ed_visits.columns:
+        raise ValueError(
+            f"admitted_in_window requires column {admission_label_col!r} on ed_visits"
+        )
     moment = _prediction_moment(snapshot_date, prediction_time)
     col = ed_visits[departure_datetime_col]
     moment = _align_tz(moment, col)
     mask = (
         (ed_visits["snapshot_date"] == snapshot_date)
         & (ed_visits["prediction_time"] == prediction_time)
-        & (ed_visits["is_admitted"].astype(bool))
+        & (ed_visits[admission_label_col].astype(bool))
         & (col > moment)
         & (col <= moment + prediction_window)
     )
@@ -243,7 +283,7 @@ def count_observed_departed_in_window(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
-    outcome_column: str = "left_subspecialty_in_window",
+    outcome_column: str = DEFAULT_DEPARTURE_OUTCOME_COLUMN,
     admission_type: Optional[str] = None,
 ) -> int:
     """Count inpatients with a true departure label on the snapshot cohort.
@@ -486,7 +526,8 @@ def count_observed(
     inpatient_visits: Optional[pd.DataFrame] = None,
     inpatient_arrivals: Optional[pd.DataFrame] = None,
     specialty: Optional[str] = None,
-    outcome_column: str = "left_subspecialty_in_window",
+    admission_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
+    outcome_column: str = DEFAULT_DEPARTURE_OUTCOME_COLUMN,
     admission_type: Optional[str] = None,
     arrival_datetime_col: str = "arrival_datetime",
     departure_datetime_col: str = "departure_datetime",
@@ -517,9 +558,12 @@ def count_observed(
         Passed to `count_observed_admitted_in_window` and
         `count_observed_arrived_and_admitted_in_window`.
         Default is `departure_datetime`.
+    admission_label_col : str, optional
+        Passed to `count_observed_admitted_in_window`.
+        Default is ``DEFAULT_ADMISSION_LABEL_COL``.
     outcome_column : str, optional
         Passed to `count_observed_departed_in_window`.
-        Default is `left_subspecialty_in_window`.
+        Default is ``DEFAULT_DEPARTURE_OUTCOME_COLUMN``.
     admission_type : str, optional
         Passed to `count_observed_departed_in_window` for route-specific
         departures targets (e.g. ``"elective"``). Default is None.
@@ -566,6 +610,7 @@ def count_observed(
             prediction_time,
             prediction_window,
             specialty=specialty,
+            admission_label_col=admission_label_col,
         )
     if observation_mode == "admitted_in_window":
         if ed_visits is None:
@@ -576,6 +621,7 @@ def count_observed(
             prediction_time,
             prediction_window,
             specialty=specialty,
+            admission_label_col=admission_label_col,
             departure_datetime_col=departure_datetime_col,
         )
     if observation_mode == "departed_in_window":

--- a/src/patientflow/evaluate/runner.py
+++ b/src/patientflow/evaluate/runner.py
@@ -50,6 +50,22 @@ def _patientflow_version() -> str:
         return "unknown"
 
 
+def evaluation_targets_for_manifest(
+    inputs: EvaluationInputs,
+) -> list[Dict[str, Any]]:
+    """Serialise ``EvaluationTarget`` rows for ``evaluation_run.yaml``."""
+    return [
+        {
+            "flow_name": t.flow_name,
+            "flow_type": t.flow_type,
+            "evaluation_mode": t.evaluation_mode,
+            "component": t.component,
+            "observation_mode": t.observation_mode,
+        }
+        for t in inputs.evaluation_targets
+    ]
+
+
 def prediction_dict_for_manifest(
     prediction_dict: Mapping[Tuple[int, int], timedelta],
 ) -> Dict[str, float]:
@@ -104,6 +120,7 @@ def write_evaluation_run_manifest(
             "eval_split": inputs.eval_split,
             "flow_selection": asdict(inputs.flow_selection),
             "n_targets": len(inputs.evaluation_targets),
+            "evaluation_targets": evaluation_targets_for_manifest(inputs),
             "prediction_dict": prediction_dict_for_manifest(inputs.prediction_dict),
             "patientflow_version": _patientflow_version(),
         },
@@ -130,8 +147,8 @@ def run_evaluation(
     Creates a timestamped subdirectory under `output_root` containing:
 
     - `evaluation_run.yaml` — run settings under ``evaluation:`` (including
-      ``prediction_dict`` and ``eval_split``), plus optional caller
-      ``training_metadata``.
+      ``evaluation_targets`` with ``observation_mode``, ``prediction_dict``,
+      and ``eval_split``), plus optional caller ``training_metadata``.
     - `scalars.json` — `evaluation_rows` plus optional `_service_summary`
       fragments merged by handlers (distribution and arrival modes attach
       per-slice service coverage).

--- a/src/patientflow/evaluate/scalars.py
+++ b/src/patientflow/evaluate/scalars.py
@@ -21,10 +21,26 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
+from patientflow.evaluate.inputs import EvaluationTarget
+
 # Reliability: minimum positive cases on the evaluated split for classifier headline metrics.
 RELIABILITY_MIN_POSITIVE_CASES: int = 30
 
 SERVICE_SENTINEL_ALL: str = "_all_"
+
+
+def scalar_target_fields(target: EvaluationTarget) -> Dict[str, Any]:
+    """Return identity fields shared by every ``evaluation_rows`` entry for *target*.
+
+    Includes ``observation_mode`` so downstream tables can interpret distribution
+    and benchmark scalars without joining back to ``EvaluationTarget`` definitions.
+    """
+    return {
+        "evaluation_mode": target.evaluation_mode,
+        "flow": target.flow_name,
+        "flow_type": target.flow_type,
+        "observation_mode": target.observation_mode,
+    }
 
 
 def scalar_merge_key(row: Mapping[str, Any]) -> Tuple[Any, ...]:
@@ -37,7 +53,8 @@ def scalar_merge_key(row: Mapping[str, Any]) -> Tuple[Any, ...]:
     ----------
     row : mapping
         Scalar row dictionary (typically including `evaluation_mode`,
-        `flow`, `service`, `component`, `prediction_time`, `model_name`).
+        `observation_mode`, `flow`, `service`, `component`, `prediction_time`,
+        `model_name`).
 
     Returns
     -------

--- a/src/patientflow/viz/randomised_pit.py
+++ b/src/patientflow/viz/randomised_pit.py
@@ -2,54 +2,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from typing import Dict, List, Optional, Tuple, Union
 from pathlib import Path
+from patientflow.evaluate.distributions import prob_to_cdf as _prob_to_cdf
 from patientflow.load import get_model_key
-
-
-def _prob_to_cdf(prob_dist):
-    """Convert probability distribution to CDF function"""
-    import pandas as pd
-
-    if isinstance(prob_dist, pd.DataFrame):
-        # Handle DataFrame: assume columns are values, data contains probabilities
-        # Take the first row if it's a DataFrame with multiple rows
-        if len(prob_dist) > 0:
-            prob_series = prob_dist.iloc[0]  # Take first row
-        else:
-            raise ValueError("Empty DataFrame provided")
-        values = list(prob_series.index)
-        probs = list(prob_series.values)
-    elif isinstance(prob_dist, pd.Series):
-        # Handle Series: index is values, values are probabilities
-        values = list(prob_dist.index)
-        probs = list(prob_dist.values)
-    elif isinstance(prob_dist, dict):
-        # Sort by keys (values) to ensure proper cumulative calculation
-        sorted_items = sorted(prob_dist.items())
-        values = [item[0] for item in sorted_items]
-        probs = [item[1] for item in sorted_items]
-    else:
-        # Array format: index = value, array[index] = probability
-        values = list(range(len(prob_dist)))
-        probs = prob_dist
-
-    # Ensure values are sorted
-    sorted_pairs = sorted(zip(values, probs))
-    values = [pair[0] for pair in sorted_pairs]
-    probs = [pair[1] for pair in sorted_pairs]
-
-    # Calculate cumulative probabilities
-    cum_probs = np.cumsum(probs)
-
-    def cdf_function(x):
-        # Return P(X <= x)
-        if x < values[0]:
-            return 0.0
-        for i, val in enumerate(values):
-            if x <= val:
-                return cum_probs[i]
-        return 1.0  # x is larger than all values
-
-    return cdf_function
 
 
 def plot_randomised_pit(

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,115 @@
+"""Tests for patientflow.evaluate.calibration."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import numpy as np
+import pytest
+
+from patientflow.evaluate.calibration import (
+    MIN_DISTRIBUTION_SNAPSHOTS,
+    benchmark_cohort_key_for_observation_mode,
+    binomial_pmf_from_n_p,
+    build_benchmark_prob_dist_dict,
+    global_p_bar_by_prediction_time,
+    rpit_cvm_calibration_score,
+)
+
+
+def _leaf(observed: int, proba: list[float]) -> dict:
+    return {
+        "agg_observed": observed,
+        "agg_predicted": {"agg_proba": np.array(proba, dtype=float)},
+    }
+
+
+def test_benchmark_cohort_key_for_observation_mode():
+    assert (
+        benchmark_cohort_key_for_observation_mode("admitted_at_some_point")
+        == "admissions"
+    )
+    assert (
+        benchmark_cohort_key_for_observation_mode("departed_in_window") == "departures"
+    )
+    assert benchmark_cohort_key_for_observation_mode("arrived_in_window") is None
+
+
+def test_global_p_bar_by_prediction_time():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "prediction_time": [(9, 0), (9, 0), (12, 0)],
+            "is_admitted": [1, 0, 1],
+        }
+    )
+    out = global_p_bar_by_prediction_time(
+        df, [(9, 0), (12, 0)], label_col="is_admitted"
+    )
+    assert out[(9, 0)] == pytest.approx(0.5)
+    assert out[(12, 0)] == pytest.approx(1.0)
+
+
+def test_rpit_cvm_returns_none_when_n_too_small():
+    snap = date(2024, 1, 1)
+    dist = {snap: _leaf(0, [1.0, 0.0])}
+    assert rpit_cvm_calibration_score(dist) is None
+    assert MIN_DISTRIBUTION_SNAPSHOTS == 2
+
+
+def test_rpit_cvm_reproducible_with_seed():
+    snap1, snap2 = date(2024, 1, 1), date(2024, 1, 2)
+    dist = {
+        snap1: _leaf(1, [0.25, 0.5, 0.25]),
+        snap2: _leaf(0, [0.7, 0.2, 0.1]),
+    }
+    a = rpit_cvm_calibration_score(dist, n_repetitions=20, seed=42)
+    b = rpit_cvm_calibration_score(dist, n_repetitions=20, seed=42)
+    assert a is not None and b is not None
+    assert a.w2_values == b.w2_values
+
+
+def test_well_calibrated_lower_w2_than_miscalibrated():
+    snap1, snap2, snap3 = date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3)
+    n, p = 10, 0.3
+    pmf = binomial_pmf_from_n_p(n, p, max_k=n)
+    good = {
+        snap1: _leaf(int(np.random.binomial(n, p)), pmf),
+        snap2: _leaf(int(np.random.binomial(n, p)), pmf),
+        snap3: _leaf(int(np.random.binomial(n, p)), pmf),
+    }
+    bad = {
+        snap1: _leaf(0, pmf),
+        snap2: _leaf(n, pmf),
+        snap3: _leaf(0, pmf),
+    }
+    good_res = rpit_cvm_calibration_score(good, n_repetitions=100, seed=1)
+    bad_res = rpit_cvm_calibration_score(bad, n_repetitions=100, seed=1)
+    assert good_res is not None and bad_res is not None
+    assert good_res.mean_w2 < bad_res.mean_w2
+
+
+def test_benchmark_build_copies_observed():
+    snap = date(2024, 1, 1)
+    pf = {snap: _leaf(3, [0.1] * 11)}
+    bench = build_benchmark_prob_dist_dict(pf, p_bar=0.3)
+    assert bench[snap]["agg_observed"] == 3
+    assert len(bench[snap]["agg_predicted"]["agg_proba"]) == 11
+
+
+def test_patientflow_lower_w2_than_binomial_benchmark():
+    """Heterogeneous observed counts vs uniform p: patientflow-shaped PMFs win."""
+    snap1, snap2, snap3 = date(2024, 1, 1), date(2024, 1, 2), date(2024, 1, 3)
+    n = 8
+    p_bar = 0.25
+    pf = {
+        snap1: _leaf(2, binomial_pmf_from_n_p(n, 0.2, max_k=n)),
+        snap2: _leaf(2, binomial_pmf_from_n_p(n, 0.35, max_k=n)),
+        snap3: _leaf(2, binomial_pmf_from_n_p(n, 0.25, max_k=n)),
+    }
+    bench = build_benchmark_prob_dist_dict(pf, p_bar=p_bar)
+    pf_res = rpit_cvm_calibration_score(pf, n_repetitions=80, seed=7)
+    bm_res = rpit_cvm_calibration_score(bench, n_repetitions=80, seed=8)
+    assert pf_res is not None and bm_res is not None
+    assert pf_res.mean_w2 < bm_res.mean_w2

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -26,10 +26,11 @@ from patientflow.evaluate.inputs import (
     normalize_prediction_dict,
 )
 from patientflow.evaluate.runner import (
+    evaluation_targets_for_manifest,
     prediction_dict_for_manifest,
     write_evaluation_run_manifest,
 )
-from patientflow.evaluate.scalars import ScalarsCollector
+from patientflow.evaluate.scalars import ScalarsCollector, scalar_target_fields
 from patientflow.load import get_model_key
 from patientflow.predict.demand import FlowSelection
 
@@ -123,6 +124,38 @@ def test_manifest_records_eval_split_and_prediction_dict(tmp_path: Path):
         prediction_dict
     )
     assert "patientflow_version" in loaded["evaluation"]
+
+
+def test_manifest_records_evaluation_targets_with_observation_mode(tmp_path: Path):
+    target = _classifier_probability_quality_target()
+    inputs = EvaluationInputs(
+        flow_selection=FlowSelection.emergency_only(),
+        prediction_dict=_uniform_prediction_dict([(6, 0)]),
+        evaluation_targets=[target],
+    )
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_evaluation_run_manifest(
+        run_dir,
+        output_root=tmp_path,
+        run_name="run",
+        inputs=inputs,
+    )
+    loaded = yaml.safe_load((run_dir / "evaluation_run.yaml").read_text())
+    assert loaded["evaluation"][
+        "evaluation_targets"
+    ] == evaluation_targets_for_manifest(inputs)
+    assert (
+        loaded["evaluation"]["evaluation_targets"][0]["observation_mode"]
+        == "admitted_at_some_point"
+    )
+
+
+def test_scalar_target_fields_includes_observation_mode():
+    target = _classifier_probability_quality_target()
+    fields = scalar_target_fields(target)
+    assert fields["observation_mode"] == target.observation_mode
+    assert fields["flow"] == target.flow_name
 
 
 def test_manifest_optional_training_metadata(tmp_path: Path):
@@ -678,3 +711,277 @@ def test_evaluate_distribution_raises_when_observation_frame_missing():
             distributions_dir=Path("/tmp/unused"),
             collector=ScalarsCollector(),
         )
+
+
+def _two_snapshot_model_key_dist(
+    model_name: str,
+    prediction_time: tuple[int, int],
+    leaves: tuple[dict, dict],
+) -> dict:
+    snap1, snap2 = date(2024, 1, 1), date(2024, 1, 2)
+    mk = get_model_key(model_name, prediction_time)
+    return {mk: {snap1: leaves[0], snap2: leaves[1]}}
+
+
+def test_evaluate_distribution_insufficient_observations_skips_epudd(
+    tmp_path: Path,
+):
+    prediction_time = (10, 0)
+    model_name = "beds"
+    snapshot = date(2024, 1, 1)
+    target = EvaluationTarget(
+        flow_name="ed_current_beds",
+        flow_type="admissions",
+        evaluation_mode="distribution",
+        component="bed_demand_ed_current",
+        observation_mode="admitted_at_some_point",
+    )
+    inputs = (
+        EvaluationInputsBuilder(
+            flow_selection=FlowSelection.emergency_only(),
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
+        )
+        .with_evaluation_targets([target])
+        .add_distributions_from_service_dict(
+            "ed_current_beds",
+            prob_dist_by_service={
+                "medical": _model_key_distribution(
+                    model_name, prediction_time, snapshot, _distribution_leaf(1)
+                ),
+            },
+            model_name=model_name,
+        )
+        .add_distribution_observations(
+            "ed_current_beds",
+            ed_visits_by_service={
+                "medical": pd.DataFrame(
+                    {
+                        "snapshot_date": [snapshot],
+                        "prediction_time": [prediction_time],
+                        "is_admitted": [1],
+                        "specialty": ["medical"],
+                    }
+                ),
+            },
+        )
+        .build()
+    )
+    collector = ScalarsCollector()
+    evaluate_distribution(
+        inputs,
+        target,
+        distributions_dir=tmp_path / "distributions",
+        collector=collector,
+    )
+    row = collector.as_list()[0]
+    assert row["skip_reason"] == "insufficient_observations"
+    assert row["charts_generated"] is False
+    assert "rpit_cvm_mean_w2" not in row
+    assert not (
+        tmp_path
+        / "distributions"
+        / "ed_current_beds"
+        / "medical"
+        / "bed_demand_ed_current.png"
+    ).exists()
+
+
+def test_evaluate_distribution_custom_admissions_label_col(tmp_path: Path):
+    prediction_time = (10, 0)
+    model_name = "beds"
+    leaf_a = _distribution_leaf()
+    leaf_b = _distribution_leaf()
+    ed_visits = pd.DataFrame(
+        [
+            {
+                "snapshot_date": date(2024, 1, 1),
+                "prediction_time": prediction_time,
+                "was_admitted": True,
+                "specialty": "medical",
+            },
+            {
+                "snapshot_date": date(2024, 1, 2),
+                "prediction_time": prediction_time,
+                "was_admitted": False,
+                "specialty": "medical",
+            },
+        ]
+    )
+    target = EvaluationTarget(
+        flow_name="ed_current_beds",
+        flow_type="admissions",
+        evaluation_mode="distribution",
+        component="bed_demand_ed_current",
+        observation_mode="admitted_at_some_point",
+    )
+    inputs = (
+        EvaluationInputsBuilder(
+            flow_selection=FlowSelection.emergency_only(),
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
+        )
+        .with_evaluation_targets([target])
+        .add_distributions_from_service_dict(
+            "ed_current_beds",
+            prob_dist_by_service={
+                "medical": _two_snapshot_model_key_dist(
+                    model_name, prediction_time, (leaf_a, leaf_b)
+                ),
+            },
+            model_name=model_name,
+        )
+        .add_distribution_observations(
+            "ed_current_beds",
+            ed_visits_by_service={"medical": ed_visits},
+        )
+        .add_distribution_benchmark_cohort(
+            admissions_ed_visits=ed_visits,
+            admissions_label_col="was_admitted",
+        )
+        .build()
+    )
+    collector = ScalarsCollector()
+    evaluate_distribution(
+        inputs,
+        target,
+        distributions_dir=tmp_path / "distributions",
+        collector=collector,
+    )
+    assert leaf_a["agg_observed"] == 1
+    assert leaf_b["agg_observed"] == 0
+
+
+def test_evaluate_distribution_rpit_cvm_and_benchmark_scalars(tmp_path: Path):
+    prediction_time = (10, 0)
+    model_name = "beds"
+    leaf_a = _distribution_leaf(1)
+    leaf_b = _distribution_leaf(0)
+    ed_visits = pd.DataFrame(
+        [
+            {
+                "snapshot_date": date(2024, 1, 1),
+                "prediction_time": prediction_time,
+                "is_admitted": 1,
+                "specialty": "medical",
+            },
+            {
+                "snapshot_date": date(2024, 1, 2),
+                "prediction_time": prediction_time,
+                "is_admitted": 0,
+                "specialty": "medical",
+            },
+        ]
+    )
+    target = EvaluationTarget(
+        flow_name="ed_current_beds",
+        flow_type="admissions",
+        evaluation_mode="distribution",
+        component="bed_demand_ed_current",
+        observation_mode="admitted_at_some_point",
+    )
+    inputs = (
+        EvaluationInputsBuilder(
+            flow_selection=FlowSelection.emergency_only(),
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
+        )
+        .with_evaluation_targets([target])
+        .add_distributions_from_service_dict(
+            "ed_current_beds",
+            prob_dist_by_service={
+                "medical": _two_snapshot_model_key_dist(
+                    model_name, prediction_time, (leaf_a, leaf_b)
+                ),
+            },
+            model_name=model_name,
+        )
+        .add_distribution_observations(
+            "ed_current_beds",
+            ed_visits_by_service={"medical": ed_visits},
+        )
+        .add_distribution_benchmark_cohort(admissions_ed_visits=ed_visits)
+        .build()
+    )
+    collector = ScalarsCollector()
+    evaluate_distribution(
+        inputs,
+        target,
+        distributions_dir=tmp_path / "distributions",
+        collector=collector,
+    )
+    row = collector.as_list()[0]
+    assert row["observation_mode"] == "admitted_at_some_point"
+    assert row["charts_generated"] is True
+    assert row["reliable"] is True
+    assert "rpit_cvm_mean_w2" in row
+    assert "rpit_cvm_w2" not in row
+    assert "rpit_cvm_benchmark_mean_w2" in row
+    assert "rpit_cvm_benchmark_w2" not in row
+    assert "rpit_cvm_w2_reduction" in row
+    assert (
+        tmp_path
+        / "distributions"
+        / "ed_current_beds"
+        / "medical"
+        / "bed_demand_ed_current.png"
+    ).exists()
+
+
+def test_evaluate_distribution_yta_has_no_benchmark_fields(tmp_path: Path):
+    prediction_time = (10, 0)
+    model_name = "beds"
+    leaf_a, leaf_b = _distribution_leaf(), _distribution_leaf()
+    moment = datetime(2024, 1, 1, 10, 0, 0)
+    arrivals = pd.DataFrame(
+        {
+            "arrival_datetime": [
+                moment + timedelta(hours=1),
+                moment + timedelta(hours=2),
+            ],
+        }
+    )
+    target = EvaluationTarget(
+        flow_name="ed_yta_beds",
+        flow_type="admissions",
+        evaluation_mode="distribution",
+        component="bed_demand_ed_yta",
+        observation_mode="arrived_in_window",
+    )
+    ed_visits = pd.DataFrame(
+        {
+            "snapshot_date": [date(2024, 1, 1), date(2024, 1, 2)],
+            "prediction_time": [prediction_time, prediction_time],
+            "is_admitted": [0, 1],
+        }
+    )
+    inputs = (
+        EvaluationInputsBuilder(
+            flow_selection=FlowSelection.emergency_only(),
+            prediction_dict=_uniform_prediction_dict([prediction_time]),
+        )
+        .with_evaluation_targets([target])
+        .add_distributions_from_service_dict(
+            "ed_yta_beds",
+            prob_dist_by_service={
+                "medical": _two_snapshot_model_key_dist(
+                    model_name, prediction_time, (leaf_a, leaf_b)
+                ),
+            },
+            model_name=model_name,
+        )
+        .add_distribution_observations(
+            "ed_yta_beds",
+            inpatient_arrivals_by_service={"medical": arrivals},
+        )
+        .add_distribution_benchmark_cohort(admissions_ed_visits=ed_visits)
+        .build()
+    )
+    collector = ScalarsCollector()
+    evaluate_distribution(
+        inputs,
+        target,
+        distributions_dir=tmp_path / "distributions",
+        collector=collector,
+    )
+    row = collector.as_list()[0]
+    assert row["observation_mode"] == "arrived_in_window"
+    assert "rpit_cvm_mean_w2" in row
+    assert "rpit_cvm_benchmark_mean_w2" not in row

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -14,6 +14,7 @@ from patientflow.evaluate.observations import (
     count_observed_arrived_and_admitted_in_window,
     count_observed_arrived_in_window,
     count_observed_departed_in_window,
+    count_observed_label_kwargs,
     validate_observation_mode_for_component,
 )
 
@@ -150,6 +151,47 @@ def test_arrived_in_window_does_not_use_ed_visits_fallback():
         inpatient_arrivals=None,
     )
     assert n == 0
+
+
+def test_count_observed_label_kwargs_from_benchmark_cohorts():
+    cohorts = {
+        "admissions": {"label_col": "was_admitted"},
+        "departures": {"label_col": "left_ward"},
+    }
+    assert count_observed_label_kwargs("admitted_at_some_point", cohorts) == {
+        "admission_label_col": "was_admitted",
+    }
+    assert count_observed_label_kwargs("departed_in_window", cohorts) == {
+        "outcome_column": "left_ward",
+    }
+    assert count_observed_label_kwargs("arrived_in_window", cohorts) == {}
+
+
+def test_admitted_at_some_point_custom_label_col():
+    df = pd.DataFrame(
+        [
+            {
+                "snapshot_date": date(2024, 1, 1),
+                "prediction_time": (10, 0),
+                "was_admitted": True,
+                "specialty": "medical",
+            },
+            {
+                "snapshot_date": date(2024, 1, 1),
+                "prediction_time": (10, 0),
+                "was_admitted": False,
+                "specialty": "medical",
+            },
+        ]
+    )
+    n = count_observed_admitted_at_some_point(
+        df,
+        date(2024, 1, 1),
+        (10, 0),
+        timedelta(hours=8),
+        admission_label_col="was_admitted",
+    )
+    assert n == 1
 
 
 def test_departed_in_window_requires_outcome_column():


### PR DESCRIPTION
- Add calibration.py and distributions.py for randomised PIT + Cramér–von Mises scoring and Binomial(n, p̄) benchmarks
- Extend evaluate_distribution to emit summary CvM scalars per service and prediction time, with optional benchmark comparison
- Store mean/std W², counts in scalars.json
- Add add_distribution_benchmark_cohort and configurable admission/departure label columns for observed counts
- Include observation_mode on scalar rows and in evaluation_run.yaml
- Update notebook 4d for benchmark cohort registration and CvM scalar review