### PR TITLE
Support YTA arrival modes in get_prob_dist_by_service

### DIFF
--- a/src/patientflow/aggregate.py
+++ b/src/patientflow/aggregate.py
@@ -715,6 +715,7 @@ def get_prob_dist_by_service(
     y2: Optional[float] = None,
     services: Optional[List[str]] = None,
     inpatient_visits: Optional[pd.DataFrame] = None,
+    inpatient_arrivals: Optional[pd.DataFrame] = None,
     component: str = "arrivals",
     use_admission_in_window_prob: Optional[bool] = None,
     outcome_column: str = "left_subspecialty_in_window",
@@ -772,6 +773,11 @@ def get_prob_dist_by_service(
         for `observation_mode='departed_in_window'` (must include
         *outcome_column*). If provided for prediction, must contain columns
         `snapshot_date`, `prediction_time`, and `elapsed_los` (as `timedelta`).
+    inpatient_arrivals : pandas.DataFrame, optional
+        Full inpatient arrivals dataframe. Required for
+        `observation_mode='arrived_in_window'` or
+        `observation_mode='arrived_and_admitted_in_window'` (must include
+        `arrival_datetime`; the latter also needs `departure_datetime`).
     component : {'arrivals', 'departures', 'net_flow'}, optional
         Which `PredictionBundle` attribute to extract. Default is `arrivals`.
         Distribution evaluation for `net_flow` is not supported.
@@ -860,6 +866,12 @@ def get_prob_dist_by_service(
             raise ValueError(
                 f"ed_visits is required for observation_mode={observation_mode!r}"
             )
+    if observation_mode in ("arrived_in_window", "arrived_and_admitted_in_window"):
+        if inpatient_arrivals is None:
+            raise ValueError(
+                f"inpatient_arrivals is required for "
+                f"observation_mode={observation_mode!r}"
+            )
     if observation_mode == "departed_in_window" and inpatient_visits is None:
         raise ValueError(
             "inpatient_visits is required for observation_mode='departed_in_window'"
@@ -905,6 +917,7 @@ def get_prob_dist_by_service(
             prediction_window=prediction_window,
             ed_visits=ed_visits,
             inpatient_visits=inpatient_visits,
+            inpatient_arrivals=inpatient_arrivals,
             specialty=svc,
             outcome_column=outcome_column,
         )

--- a/src/patientflow/evaluate/observations.py
+++ b/src/patientflow/evaluate/observations.py
@@ -77,7 +77,17 @@ DEPARTURES_DISTRIBUTION_ADMISSION_TYPE: dict[str, str] = {
     "departures_emergency": "emergency",
 }
 
-_ARRIVAL_OBSERVATION_MODES = frozenset({"admitted_at_some_point", "admitted_in_window"})
+_ARRIVAL_OBSERVATION_MODES = frozenset(
+    {
+        "admitted_at_some_point",
+        "admitted_in_window",
+        "arrived_in_window",
+        "arrived_and_admitted_in_window",
+    }
+)
+_ED_CURRENT_ARRIVAL_OBSERVATION_MODES = frozenset(
+    {"admitted_at_some_point", "admitted_in_window"}
+)
 _DEPARTURE_OBSERVATION_MODES = frozenset({"departed_in_window"})
 
 
@@ -263,7 +273,7 @@ def count_observed_applies_specialty_filter(observation_mode: str) -> bool:
     snapshot modes use per-service frames from ``add_distribution_observations``
     (for example YTA ``is_child`` for paediatric); those cohorts are already scoped.
     """
-    return observation_mode in _ARRIVAL_OBSERVATION_MODES
+    return observation_mode in _ED_CURRENT_ARRIVAL_OBSERVATION_MODES
 
 
 def admission_type_filter_for_distribution_component(

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -582,6 +582,88 @@ class TestGetProbDistByService(unittest.TestCase):
             flow_selection=FlowSelection.default(),
         )
 
+    @staticmethod
+    def _ed_yta_only_flow() -> FlowSelection:
+        return FlowSelection.custom(
+            include_ed_current=False,
+            include_ed_yta=True,
+            include_non_ed_yta=False,
+            include_elective_yta=False,
+            include_transfers_in=False,
+            include_departures=False,
+        )
+
+    def test_admitted_in_window_requires_ed_visits(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_prob_dist_by_service(
+                None,
+                [date(2024, 1, 1)],
+                (10, 0),
+                (None,) * 7,
+                ["medical"],
+                timedelta(hours=2),
+                self._ed_only_flow(),
+                observation_mode="admitted_in_window",
+            )
+        self.assertIn("ed_visits", str(ctx.exception))
+
+    def test_arrived_in_window_requires_inpatient_arrivals(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_prob_dist_by_service(
+                None,
+                [date(2024, 1, 1)],
+                (10, 0),
+                (None,) * 7,
+                ["medical"],
+                timedelta(hours=2),
+                self._ed_yta_only_flow(),
+                observation_mode="arrived_in_window",
+            )
+        self.assertIn("inpatient_arrivals", str(ctx.exception))
+
+    @patch("patientflow.predict.service.build_service_data")
+    @patch("patientflow.predict.demand.DemandPredictor")
+    def test_arrived_in_window_yta_without_ed_visits(
+        self, mock_predictor_cls, mock_build_service_data
+    ):
+        mock_build_service_data.return_value = {"medical": MagicMock()}
+        mock_predictor_cls.return_value.predict_service.return_value = (
+            self._mock_prediction_bundle()
+        )
+        moment = datetime(2024, 1, 1, 10, 0, 0)
+        inpatient_arrivals = pd.DataFrame(
+            [
+                {
+                    "arrival_datetime": moment + timedelta(hours=2),
+                    "specialty": "medical",
+                },
+                {
+                    "arrival_datetime": moment + timedelta(hours=10),
+                    "specialty": "medical",
+                },
+                {
+                    "arrival_datetime": moment + timedelta(hours=2),
+                    "specialty": "surgical",
+                },
+            ]
+        )
+        result = get_prob_dist_by_service(
+            None,
+            [date(2024, 1, 1)],
+            (10, 0),
+            (None,) * 7,
+            ["medical"],
+            timedelta(hours=8),
+            self._ed_yta_only_flow(),
+            observation_mode="arrived_in_window",
+            inpatient_arrivals=inpatient_arrivals,
+            component="arrivals",
+            services=["medical"],
+        )
+        leaf = result["medical"][date(2024, 1, 1)]
+        self.assertEqual(leaf["agg_observed"], 1)
+        self.assertIn("agg_proba", leaf["agg_predicted"].columns)
+
     def test_missing_ed_visits_raises_when_ed_current_included(self):
         with self.assertRaises(ValueError) as ctx:
             get_prob_dist_by_service(

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -346,6 +346,10 @@ def test_departed_in_window_filters_admission_type():
 
 def test_validate_observation_mode_for_component():
     validate_observation_mode_for_component("arrivals", "admitted_in_window")
+    validate_observation_mode_for_component("arrivals", "arrived_in_window")
+    validate_observation_mode_for_component(
+        "arrivals", "arrived_and_admitted_in_window"
+    )
     validate_observation_mode_for_component("departures", "departed_in_window")
     with pytest.raises(ValueError, match="arrivals"):
         validate_observation_mode_for_component("arrivals", "departed_in_window")


### PR DESCRIPTION
- Add inpatient_arrivals parameter and pass through to count_observed
- Allow arrived_in_window and arrived_and_admitted_in_window on component=arrivals
- Keep ED-only specialty filtering separate from YTA arrival modes
- Add aggregate and observation validation tests