### PR TITLE
make service-unit column names configurable

### DIFF
--- a/src/patientflow/evaluate/observations.py
+++ b/src/patientflow/evaluate/observations.py
@@ -46,7 +46,7 @@ departed_in_window
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Any, Mapping, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 import pandas as pd
 
@@ -135,6 +135,7 @@ def count_observed_admitted_at_some_point(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    specialty_col: str = "specialty",
     admission_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
 ) -> int:
     """Count ED snapshot rows with a true admission label for the prediction moment.
@@ -147,7 +148,7 @@ def count_observed_admitted_at_some_point(
     ----------
     ed_visits : pandas.DataFrame
         ED visits with columns *snapshot_date*, *prediction_time*,
-        *admission_label_col*, and *specialty* when *specialty* is not None.
+        *admission_label_col*, and *specialty_col* when *specialty* is not None.
     admission_label_col : str, optional
         Boolean admission label column. Default is ``DEFAULT_ADMISSION_LABEL_COL``.
     snapshot_date : datetime.date
@@ -158,6 +159,8 @@ def count_observed_admitted_at_some_point(
         Unused; retained for a uniform call signature across strategies.
     specialty : str, optional
         If given, restrict to this specialty value. Default is None (no filter).
+    specialty_col : str, default='specialty'
+        Column used when *specialty* is set.
 
     Returns
     -------
@@ -175,7 +178,7 @@ def count_observed_admitted_at_some_point(
         & (ed_visits[admission_label_col].astype(bool))
     )
     if specialty is not None:
-        mask = mask & (ed_visits["specialty"] == specialty)
+        mask = mask & (ed_visits[specialty_col] == specialty)
     return int(mask.sum())
 
 
@@ -186,6 +189,7 @@ def count_observed_admitted_in_window(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    specialty_col: str = "specialty",
     admission_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
     departure_datetime_col: str = "departure_datetime",
 ) -> int:
@@ -205,7 +209,7 @@ def count_observed_admitted_in_window(
     ----------
     ed_visits : pandas.DataFrame
         Must include *departure_datetime_col*, *snapshot_date*, *prediction_time*,
-        *admission_label_col*, and *specialty* if *specialty* is set.
+        *admission_label_col*, and *specialty_col* if *specialty* is set.
     admission_label_col : str, optional
         Boolean admission label column. Default is ``DEFAULT_ADMISSION_LABEL_COL``.
     snapshot_date : datetime.date
@@ -216,6 +220,8 @@ def count_observed_admitted_in_window(
         Upper bound added to the prediction moment for the inclusion window.
     specialty : str, optional
         If given, restrict to this specialty. Default is None (no filter).
+    specialty_col : str, default='specialty'
+        Column used when *specialty* is set.
     departure_datetime_col : str, optional
         Column for leave-ED (ward admission) time. Default is
         `departure_datetime`.
@@ -250,7 +256,7 @@ def count_observed_admitted_in_window(
         & (col <= moment + prediction_window)
     )
     if specialty is not None:
-        mask = mask & (ed_visits["specialty"] == specialty)
+        mask = mask & (ed_visits[specialty_col] == specialty)
     return int(mask.sum())
 
 
@@ -269,9 +275,10 @@ def count_observed_applies_specialty_filter(observation_mode: str) -> bool:
     """Whether ``count_observed`` should filter by the service name on a specialty column.
 
     ED current modes register the same ``ed_visits`` snapshot frame for every
-    service; the service key selects rows via ``specialty``. Arrival and inpatient
-    snapshot modes use per-service frames from ``add_distribution_observations``
-    (for example YTA ``is_child`` for paediatric); those cohorts are already scoped.
+    service; the service key selects rows via *specialty_col* (default
+    ``specialty``). Arrival and inpatient snapshot modes use per-service frames
+    from ``add_distribution_observations`` (for example YTA ``is_child`` for
+    paediatric); those cohorts are already scoped.
     """
     return observation_mode in _ED_CURRENT_ARRIVAL_OBSERVATION_MODES
 
@@ -293,6 +300,7 @@ def count_observed_departed_in_window(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    specialty_col: str = "current_subspecialty",
     outcome_column: str = DEFAULT_DEPARTURE_OUTCOME_COLUMN,
     admission_type: Optional[str] = None,
 ) -> int:
@@ -300,14 +308,13 @@ def count_observed_departed_in_window(
 
     Uses boolean *outcome_column* on inpatient snapshot rows at
     (*snapshot_date*, *prediction_time*). The label encodes whether the patient
-    left the current subspecialty within the prediction window.
+    left the current service unit within the prediction window.
 
     Parameters
     ----------
     inpatient_visits : pandas.DataFrame
         Inpatient snapshots with *snapshot_date*, *prediction_time*, and
-        *outcome_column*. Optional *current_subspecialty* or *specialty* when
-        *specialty* is set.
+        *outcome_column*. Optional *specialty_col* when *specialty* is set.
     snapshot_date : datetime.date
         Snapshot calendar date.
     prediction_time : tuple of (int, int)
@@ -315,8 +322,11 @@ def count_observed_departed_in_window(
     prediction_window : datetime.timedelta
         Unused; retained for a uniform call signature across strategies.
     specialty : str, optional
-        If given, filter by *current_subspecialty* or *specialty* when present.
+        If given, filter by *specialty_col* when that column is present.
         Default is None (no filter).
+    specialty_col : str, default='current_subspecialty'
+        Service-unit column used when *specialty* is set. Frames that store
+        the unit under another name (e.g. ``specialty``) should pass that name.
     outcome_column : str, optional
         Boolean column naming departure within the window on the snapshot
         cohort. Default is `left_subspecialty_in_window`.
@@ -344,10 +354,8 @@ def count_observed_departed_in_window(
         & (inpatient_visits["prediction_time"] == prediction_time)
         & (inpatient_visits[outcome_column].astype(bool))
     )
-    if specialty is not None and "current_subspecialty" in inpatient_visits.columns:
-        mask = mask & (inpatient_visits["current_subspecialty"] == specialty)
-    elif specialty is not None and "specialty" in inpatient_visits.columns:
-        mask = mask & (inpatient_visits["specialty"] == specialty)
+    if specialty is not None and specialty_col in inpatient_visits.columns:
+        mask = mask & (inpatient_visits[specialty_col] == specialty)
     if admission_type is not None:
         if "admission_type" not in inpatient_visits.columns:
             raise ValueError(
@@ -365,6 +373,7 @@ def count_observed_arrived_in_window(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    specialty_col: str = "specialty",
     arrival_datetime_col: str = "arrival_datetime",
 ) -> int:
     """Count arrivals with arrival time in `(moment, moment + window]`.
@@ -383,8 +392,10 @@ def count_observed_arrived_in_window(
     prediction_window : datetime.timedelta
         Upper bound added to the prediction moment.
     specialty : str, optional
-        If given and a *specialty* column exists, filter to that value.
+        If given and *specialty_col* exists, filter to that value.
         Default is None (no filter).
+    specialty_col : str, default='specialty'
+        Service-unit column used when *specialty* is set.
     arrival_datetime_col : str, optional
         Column name for arrival timestamp. Default is `arrival_datetime`.
 
@@ -407,8 +418,8 @@ def count_observed_arrived_in_window(
     col = inpatient_arrivals[arrival_datetime_col]
     moment = _align_tz(moment, col)
     mask = (col > moment) & (col <= moment + prediction_window)
-    if specialty is not None and "specialty" in inpatient_arrivals.columns:
-        mask = mask & (inpatient_arrivals["specialty"] == specialty)
+    if specialty is not None and specialty_col in inpatient_arrivals.columns:
+        mask = mask & (inpatient_arrivals[specialty_col] == specialty)
     return int(mask.sum())
 
 
@@ -419,6 +430,7 @@ def count_observed_arrived_and_admitted_in_window(
     prediction_window: timedelta,
     *,
     specialty: Optional[str] = None,
+    specialty_col: str = "specialty",
     arrival_datetime_col: str = "arrival_datetime",
     departure_datetime_col: str = "departure_datetime",
 ) -> int:
@@ -441,8 +453,10 @@ def count_observed_arrived_and_admitted_in_window(
     prediction_window : datetime.timedelta
         Upper bound added to the prediction moment for both windows.
     specialty : str, optional
-        If given and a *specialty* column exists, filter to that value.
+        If given and *specialty_col* exists, filter to that value.
         Default is None (no filter).
+    specialty_col : str, default='specialty'
+        Service-unit column used when *specialty* is set.
     arrival_datetime_col : str, optional
         Column name for arrival time. Default is `arrival_datetime`.
     departure_datetime_col : str, optional
@@ -478,8 +492,8 @@ def count_observed_arrived_and_admitted_in_window(
         & (dep > moment_dep)
         & (dep <= window_end_dep)
     )
-    if specialty is not None and "specialty" in inpatient_arrivals.columns:
-        mask = mask & (inpatient_arrivals["specialty"] == specialty)
+    if specialty is not None and specialty_col in inpatient_arrivals.columns:
+        mask = mask & (inpatient_arrivals[specialty_col] == specialty)
     return int(mask.sum())
 
 
@@ -536,6 +550,7 @@ def count_observed(
     inpatient_visits: Optional[pd.DataFrame] = None,
     inpatient_arrivals: Optional[pd.DataFrame] = None,
     specialty: Optional[str] = None,
+    specialty_col: Optional[str] = None,
     admission_label_col: str = DEFAULT_ADMISSION_LABEL_COL,
     outcome_column: str = DEFAULT_DEPARTURE_OUTCOME_COLUMN,
     admission_type: Optional[str] = None,
@@ -564,6 +579,10 @@ def count_observed(
     specialty : str, optional
         Passed through to the underlying counter when supported.
         Default is None (no filter).
+    specialty_col : str, optional
+        Service-unit column name passed to the underlying counter. When omitted,
+        each counter uses its own default (``specialty`` for ED/arrivals modes;
+        ``current_subspecialty`` for `departed_in_window`).
     departure_datetime_col : str, optional
         Passed to `count_observed_admitted_in_window` and
         `count_observed_arrived_and_admitted_in_window`.
@@ -611,6 +630,9 @@ def count_observed(
             f"Unknown observation_mode {observation_mode!r}; "
             f"expected one of {OBSERVATION_MODES}"
         )
+    specialty_kwargs: Dict[str, str] = (
+        {"specialty_col": specialty_col} if specialty_col is not None else {}
+    )
     if observation_mode == "admitted_at_some_point":
         if ed_visits is None:
             return 0
@@ -621,6 +643,7 @@ def count_observed(
             prediction_window,
             specialty=specialty,
             admission_label_col=admission_label_col,
+            **specialty_kwargs,
         )
     if observation_mode == "admitted_in_window":
         if ed_visits is None:
@@ -633,6 +656,7 @@ def count_observed(
             specialty=specialty,
             admission_label_col=admission_label_col,
             departure_datetime_col=departure_datetime_col,
+            **specialty_kwargs,
         )
     if observation_mode == "departed_in_window":
         if inpatient_visits is None:
@@ -645,6 +669,7 @@ def count_observed(
             specialty=specialty,
             outcome_column=outcome_column,
             admission_type=admission_type,
+            **specialty_kwargs,
         )
     if observation_mode == "arrived_in_window":
         if inpatient_arrivals is None:
@@ -656,6 +681,7 @@ def count_observed(
             prediction_window,
             specialty=specialty,
             arrival_datetime_col=arrival_datetime_col,
+            **specialty_kwargs,
         )
     if observation_mode == "arrived_and_admitted_in_window":
         if inpatient_arrivals is None:
@@ -668,5 +694,6 @@ def count_observed(
             specialty=specialty,
             arrival_datetime_col=arrival_datetime_col,
             departure_datetime_col=departure_datetime_col,
+            **specialty_kwargs,
         )
     raise RuntimeError("unreachable")  # pragma: no cover

--- a/src/patientflow/predict/service.py
+++ b/src/patientflow/predict/service.py
@@ -879,6 +879,7 @@ def _process_inpatients_for_specialty_by_admission_type(
     inpatient_snapshots: pd.DataFrame,
     prob_departure_series: pd.Series,
     admission_type: str,
+    service_col: str = "current_subspecialty",
 ) -> Dict[str, Any]:
     """Process inpatients for a specific specialty and admission type.
 
@@ -892,6 +893,8 @@ def _process_inpatients_for_specialty_by_admission_type(
         Series containing departure probabilities for the admission type
     admission_type : str
         The admission type to process ("elective" or "emergency")
+    service_col : str, default='current_subspecialty'
+        Column naming the patient's current service unit.
 
     Returns
     -------
@@ -899,7 +902,7 @@ def _process_inpatients_for_specialty_by_admission_type(
         Dictionary containing processed inpatient data for the specialty and admission type
     """
     # Process inpatients for the specific admission type (no weighting required)
-    admission_type_mask = (inpatient_snapshots["current_subspecialty"] == spec) & (
+    admission_type_mask = (inpatient_snapshots[service_col] == spec) & (
         inpatient_snapshots["admission_type"] == admission_type
     )
     admission_type_indices = inpatient_snapshots[admission_type_mask].index
@@ -1043,6 +1046,7 @@ def _build_legacy_flows(
     y2: Optional[float],
     base_probs: Dict[str, Any],
     prediction_date: Optional[date] = None,
+    inpatient_service_col: str = "current_subspecialty",
 ) -> Dict[str, Dict[str, Any]]:
     """Build flows for all specialties using processing logic.
 
@@ -1084,10 +1088,18 @@ def _build_legacy_flows(
         # Process inpatients
         if inpatient_snapshots is not None:
             elective_data = _process_inpatients_for_specialty_by_admission_type(
-                spec, inpatient_snapshots, prob_departure_after_elective, "elective"
+                spec,
+                inpatient_snapshots,
+                prob_departure_after_elective,
+                "elective",
+                service_col=inpatient_service_col,
             )
             emergency_data = _process_inpatients_for_specialty_by_admission_type(
-                spec, inpatient_snapshots, prob_departure_after_emergency, "emergency"
+                spec,
+                inpatient_snapshots,
+                prob_departure_after_emergency,
+                "emergency",
+                service_col=inpatient_service_col,
             )
         else:
             elective_data = {
@@ -1129,6 +1141,7 @@ def _finalise_service_data(
     inpatient_snapshots: Optional[pd.DataFrame] = None,
     prob_departure_after_elective: Optional[pd.DataFrame] = None,
     prob_departure_after_emergency: Optional[pd.DataFrame] = None,
+    inpatient_service_col: str = "current_subspecialty",
 ) -> Dict[str, ServicePredictionInputs]:
     """Add transfers and create final ServicePredictionInputs objects.
 
@@ -1151,6 +1164,7 @@ def _finalise_service_data(
             specialties,
             prob_departure_after_elective=prob_departure_after_elective,
             prob_departure_after_emergency=prob_departure_after_emergency,
+            source_col=inpatient_service_col,
         )
     else:
         # If no transfer model, assume 0 transfers
@@ -1225,6 +1239,7 @@ def build_service_data(
     cdf_cut_points: Optional[List[float]] = None,
     use_admission_in_window_prob: bool = True,
     prediction_date: Optional[date] = None,
+    inpatient_service_col: str = "current_subspecialty",
 ) -> Dict[str, ServicePredictionInputs]:
     """Build per-service inputs for downstream roll-up.
 
@@ -1281,6 +1296,10 @@ def build_service_data(
         weekday stratification (the default for incoming admission predictors).
         When omitted (default), behaviour matches previous releases: pooled
         profiles are used and legacy callers stay warning-free.
+    inpatient_service_col : str, default='current_subspecialty'
+        Column on *inpatient_snapshots* naming the patient's current service
+        unit. Used to filter departures by service and as the source column
+        for transfer routing.
 
     Returns
     -------
@@ -1359,6 +1378,7 @@ def build_service_data(
         y2,
         base_probs,
         prediction_date=prediction_date,
+        inpatient_service_col=inpatient_service_col,
     )
 
     return _finalise_service_data(
@@ -1369,4 +1389,5 @@ def build_service_data(
         inpatient_snapshots=base_probs["inpatient_snapshots"],
         prob_departure_after_elective=base_probs["prob_departure_after_elective"],
         prob_departure_after_emergency=base_probs["prob_departure_after_emergency"],
+        inpatient_service_col=inpatient_service_col,
     )

--- a/src/patientflow/predict/transfers.py
+++ b/src/patientflow/predict/transfers.py
@@ -273,6 +273,7 @@ def compute_transfer_arrivals(
     services: List[str],
     prob_departure_after_elective: Optional[Union[pd.DataFrame, pd.Series]] = None,
     prob_departure_after_emergency: Optional[Union[pd.DataFrame, pd.Series]] = None,
+    source_col: str = "current_subspecialty",
 ) -> Dict[str, Dict[str, np.ndarray]]:
     """Compute subgroup-aware transfer-arrival PMFs for each service.
 
@@ -296,9 +297,9 @@ def compute_transfer_arrivals(
     ----------
     inpatient_snapshots : pandas.DataFrame or None
         Current inpatients, indexed consistently with the departure probability
-        containers. Must expose ``current_subspecialty``, ``admission_type`` and
-        the columns used by the subgroup predicates (``age``/``sex``). When
-        ``None`` (or empty), all targets receive a zero-arrivals PMF.
+        containers. Must expose *source_col*, ``admission_type`` and the columns
+        used by the subgroup predicates (``age``/``sex``). When ``None`` (or
+        empty), all targets receive a zero-arrivals PMF.
     transfer_model : TransferProbabilityEstimator
         Fitted estimator providing per-subgroup transfer tables.
     services : list of str
@@ -309,6 +310,10 @@ def compute_transfer_arrivals(
         A DataFrame must contain a ``pred_proba`` column.
     prob_departure_after_emergency : pandas.DataFrame or pandas.Series, optional
         As above for emergency inpatients.
+    source_col : str, default='current_subspecialty'
+        Column naming the patient's current service unit (source of a potential
+        transfer). Matches
+        [TransferProbabilityEstimator.source_col][patientflow.predictors.transfer_predictor.TransferProbabilityEstimator].
 
     Returns
     -------
@@ -352,7 +357,7 @@ def compute_transfer_arrivals(
     if inpatient_snapshots is None or inpatient_snapshots.empty:
         return predicted_arrivals
 
-    required_cols = {"current_subspecialty", "admission_type"}
+    required_cols = {source_col, "admission_type"}
     if not required_cols.issubset(inpatient_snapshots.columns):
         return predicted_arrivals
 
@@ -389,7 +394,7 @@ def compute_transfer_arrivals(
 
         for source_service in services:
             source_mask = cohort_mask & (
-                inpatient_snapshots["current_subspecialty"] == source_service
+                inpatient_snapshots[source_col] == source_service
             )
             source_index = inpatient_snapshots.index[source_mask]
             if len(source_index) == 0:

--- a/src/patientflow/train/sequence_predictor.py
+++ b/src/patientflow/train/sequence_predictor.py
@@ -19,7 +19,10 @@ from patientflow.predictors.sequence_to_outcome_predictor import (
 )
 
 
-def get_default_visits(admitted: DataFrame) -> DataFrame:
+def get_default_visits(
+    admitted: DataFrame,
+    specialty_col: str = "specialty",
+) -> DataFrame:
     """
     Filter a dataframe of patient visits to include only non-paediatric patients.
 
@@ -31,7 +34,9 @@ def get_default_visits(admitted: DataFrame) -> DataFrame:
     ----------
     admitted : DataFrame
         A pandas DataFrame containing patient visit information. Must include either
-        'age_on_arrival' or 'age_group' columns, and a 'specialty' column.
+        'age_on_arrival' or 'age_group' columns, and *specialty_col*.
+    specialty_col : str, default='specialty'
+        Column naming the patient's specialty / service unit.
 
     Returns
     -------
@@ -63,7 +68,7 @@ def get_default_visits(admitted: DataFrame) -> DataFrame:
     # Filter out paediatric patients based on both age criteria and specialty
     filtered_admitted = admitted[
         admitted.apply(opposite_special_category_func, axis=1)
-        & (admitted["specialty"] != special_category_key)
+        & (admitted[specialty_col] != special_category_key)
     ]
 
     return filtered_admitted
@@ -76,6 +81,7 @@ def train_sequence_predictor(
     input_var: str,
     grouping_var: str,
     outcome_var: str,
+    specialty_col: str = "specialty",
 ) -> SequenceToOutcomePredictor:
     """
     Train a specialty prediction model.
@@ -94,6 +100,9 @@ def train_sequence_predictor(
         Column name for grouping sequence.
     outcome_var : str
         Column name for target variable.
+    specialty_col : str, default='specialty'
+        Column naming the patient's specialty / service unit. Used to drop rows
+        with a missing specialty and to exclude the special (paediatric) category.
 
     Returns
     -------
@@ -102,9 +111,9 @@ def train_sequence_predictor(
     """
     visits_single = select_one_snapshot_per_visit(train_visits, visit_col)
     admitted = visits_single[
-        (visits_single.is_admitted) & ~(visits_single.specialty.isnull())
+        (visits_single.is_admitted) & ~(visits_single[specialty_col].isnull())
     ]
-    filtered_admitted = get_default_visits(admitted)
+    filtered_admitted = get_default_visits(admitted, specialty_col=specialty_col)
 
     filtered_admitted.loc[:, input_var] = filtered_admitted[input_var].apply(
         lambda x: tuple(x) if x else ()

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -234,6 +234,7 @@ def test_departed_in_window_counts_label_not_datetime():
         (10, 0),
         timedelta(hours=8),
         specialty="medical",
+        specialty_col="specialty",
     )
     assert n == 1
 
@@ -339,9 +340,52 @@ def test_departed_in_window_filters_admission_type():
         (10, 0),
         timedelta(hours=8),
         specialty="medical",
+        specialty_col="specialty",
         admission_type="elective",
     )
     assert n == 1
+
+
+def test_admitted_at_some_point_non_default_specialty_col():
+    df = pd.DataFrame(
+        [
+            {
+                "snapshot_date": date(2024, 1, 1),
+                "prediction_time": (10, 0),
+                "is_admitted": 1,
+                "reporting_unit": "medical",
+            },
+            {
+                "snapshot_date": date(2024, 1, 1),
+                "prediction_time": (10, 0),
+                "is_admitted": 1,
+                "reporting_unit": "surgical",
+            },
+        ]
+    )
+    n = count_observed_admitted_at_some_point(
+        df,
+        date(2024, 1, 1),
+        (10, 0),
+        timedelta(hours=8),
+        specialty="medical",
+        specialty_col="reporting_unit",
+    )
+    assert n == 1
+
+
+def test_get_default_visits_non_default_specialty_col():
+    from patientflow.train.sequence_predictor import get_default_visits
+
+    admitted = pd.DataFrame(
+        {
+            "age_on_arrival": [40, 5, 50],
+            "reporting_unit": ["medical", "paediatric", "paediatric"],
+        }
+    )
+    filtered = get_default_visits(admitted, specialty_col="reporting_unit")
+    assert len(filtered) == 1
+    assert filtered.iloc[0]["reporting_unit"] == "medical"
 
 
 def test_validate_observation_mode_for_component():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -666,6 +666,44 @@ class TestBuildServiceData(unittest.TestCase):
             r_none_b["medical"].inflows["elective_yta"].distribution,
         )
 
+    def test_non_default_inpatient_service_col(self):
+        """build_service_data accepts a non-default inpatient service column."""
+        ed_snapshots = self._make_snapshots(40)
+        inpatient_snapshots = self._make_inpatient_snapshots(30)
+        inpatient_snapshots = inpatient_snapshots.rename(
+            columns={"current_subspecialty": "reporting_unit"}
+        )
+        # Put all elective inpatients into one service so departures are non-trivial.
+        elective_mask = inpatient_snapshots["admission_type"] == "elective"
+        inpatient_snapshots.loc[elective_mask, "reporting_unit"] = "medical"
+
+        result = build_service_data(
+            models=self.models,
+            prediction_time=self.prediction_time,
+            ed_snapshots=ed_snapshots,
+            inpatient_snapshots=inpatient_snapshots,
+            specialties=self.specialties,
+            prediction_window=self.prediction_window,
+            flow_selection=FlowSelection.default(),
+            x1=self.x1,
+            y1=self.y1,
+            x2=self.x2,
+            y2=self.y2,
+            inpatient_service_col="reporting_unit",
+        )
+
+        self.assertIn("medical", result)
+        medical_elective = np.asarray(
+            result["medical"].outflows["elective_departures"].distribution
+        )
+        # At least one elective medical inpatient → P(0) < 1.
+        self.assertLess(medical_elective[0], 1.0)
+        for other in ("surgical", "haem/onc", "paediatric"):
+            other_pmf = np.asarray(
+                result[other].outflows["elective_departures"].distribution
+            )
+            self.assertAlmostEqual(other_pmf[0], 1.0)
+
 
 class TestComputeTransferArrivalsSmoke(unittest.TestCase):
     """Smoke test for the re-exported compute_transfer_arrivals.

--- a/tests/test_transfer_arrivals.py
+++ b/tests/test_transfer_arrivals.py
@@ -406,6 +406,30 @@ class TestComputeTransferArrivalsSubgroup(unittest.TestCase):
         # Female routes to gynae with effective prob 0.5 -> EV 0.5.
         self.assertAlmostEqual(_expected_value(result["emergency"]["gynae"]), 0.5)
 
+    def test_non_default_source_col(self):
+        """source_col selects the service-unit column used for filtering sources."""
+        snapshots = pd.DataFrame(
+            {
+                "reporting_unit": ["cardiology", "cardiology"],
+                "admission_type": ["emergency", "emergency"],
+                "age_on_arrival": [30, 30],
+                "sex": ["F", "M"],
+            }
+        )
+        prob = pd.DataFrame({"pred_proba": [1.0, 1.0]}, index=snapshots.index)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = compute_transfer_arrivals(
+                snapshots,
+                self.model,
+                self.services,
+                prob_departure_after_emergency=prob,
+                source_col="reporting_unit",
+            )
+        # Female -> gynae, male -> surgery; both with p_depart=1.
+        self.assertAlmostEqual(_expected_value(result["emergency"]["gynae"]), 1.0)
+        self.assertAlmostEqual(_expected_value(result["emergency"]["surgery"]), 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- add inpatient_service_col / source_col / specialty_col params with existing defaults
- cover non-default names in build_service_data, transfers, evaluate, and train tests