### PR TITLE
Individual feature plots

### DIFF
--- a/src/patientflow/evaluate/handlers.py
+++ b/src/patientflow/evaluate/handlers.py
@@ -729,7 +729,9 @@ def evaluate_classifier_model_diagnostics(
     -----
     Skips quietly when no classifier block is registered for the flow. Uses
     `patientflow.viz.features.plot_features` and, when available,
-    `patientflow.viz.shap.plot_shap`. Closes matplotlib figures after each plot.
+    `patientflow.viz.shap.plot_shap`. Writes a multi-clock ``features.png``
+    strip plus per-clock ``features_HHMM.png`` when several models share the
+    flow (mirroring SHAP). Closes matplotlib figures after each plot.
     Charts are skipped when ``charts="none"``; scalar rows still emit.
     """
     chart_mode = normalize_chart_mode(charts)
@@ -757,8 +759,28 @@ def evaluate_classifier_model_diagnostics(
         )
         plt.close("all")
 
+        multi_clock = len(models) > 1
+        if multi_clock:
+            for m in models:
+                plot_features(
+                    [m],
+                    media_file_path=classifiers_dir,
+                    file_name=_disambiguate_classifier_plot_filename(
+                        "features.png",
+                        m.training_results.prediction_time,
+                        multi_clock=True,
+                    ),
+                    suptitle=_classifier_diagnostics_suptitle(
+                        target,
+                        "feature importances",
+                        eval_split=eval_split,
+                        prediction_time=m.training_results.prediction_time,
+                    ),
+                    return_figure=False,
+                )
+                plt.close("all")
+
         if SHAP_AVAILABLE and plot_shap is not None:
-            multi_clock = len(models) > 1
             for m in models:
                 plot_shap(
                     [m],

--- a/src/patientflow/train/classifiers.py
+++ b/src/patientflow/train/classifiers.py
@@ -91,6 +91,22 @@ def _timedelta_to_float_seconds(X: npt.NDArray[Any]) -> npt.NDArray[np.float64]:
     return sec.reshape(arr.shape[0], -1)
 
 
+def _bool_to_float(X: Any) -> npt.NDArray[np.float64]:
+    """Map boolean values to float: True→1.0, False→0.0, missing→NaN.
+
+    Accepts DataFrame / Series / ndarray inputs from ``ColumnTransformer``.
+    Missingness (``pd.NA``, ``None``, ``NaN``) is preserved as ``NaN`` rather
+    than imputed to False.
+    """
+    if isinstance(X, Series):
+        frame = X.to_frame()
+    elif isinstance(X, DataFrame):
+        frame = X
+    else:
+        frame = DataFrame(np.asarray(X))
+    return frame.astype("Float64").to_numpy(dtype=np.float64, na_value=np.nan)
+
+
 def infer_feature_kind(
     series: Series,
     col: str,
@@ -101,10 +117,14 @@ def infer_feature_kind(
     This is the single source of truth for both ``create_column_transformer``
     and ``FeatureColumnTransformer`` defaults. Checks are ordered from explicit
     contracts (ordinal mapping, concrete dtypes) to broad fallbacks.
+
+    Boolean routing covers both numpy ``bool`` and pandas nullable
+    ``BooleanDtype`` (``True`` / ``False`` / ``<NA>``). Object columns with
+    mixed Python types (e.g. ``True`` / ``None``) remain categorical.
     """
     if col in ordinal_mappings:
         return FeatureKind.ORDINAL
-    if series.dtype == "bool":
+    if series.dtype == "bool" or isinstance(series.dtype, pd.BooleanDtype):
         return FeatureKind.BOOLEAN
     if pd.api.types.is_timedelta64_dtype(series):
         return FeatureKind.TIMEDELTA
@@ -144,7 +164,9 @@ def _make_transformer_for_kind(
     col: str,
     kind: FeatureKind,
     ordinal_mappings: Dict[str, List[Any]],
-) -> Union[OrdinalEncoder, OneHotEncoder, StandardScaler, Pipeline, str]:
+) -> Union[
+    OrdinalEncoder, OneHotEncoder, StandardScaler, Pipeline, FunctionTransformer, str
+]:
     if kind == FeatureKind.ORDINAL:
         return OrdinalEncoder(
             categories=[ordinal_mappings[col]],
@@ -152,7 +174,10 @@ def _make_transformer_for_kind(
             unknown_value=np.nan,
         )
     if kind == FeatureKind.BOOLEAN:
-        return "passthrough"
+        return FunctionTransformer(
+            _bool_to_float,
+            feature_names_out="one-to-one",
+        )
     if kind == FeatureKind.TIMEDELTA:
         return Pipeline(
             [
@@ -421,7 +446,14 @@ def create_column_transformer(
     transformers: List[
         Tuple[
             str,
-            Union[OrdinalEncoder, OneHotEncoder, StandardScaler, Pipeline, str],
+            Union[
+                OrdinalEncoder,
+                OneHotEncoder,
+                StandardScaler,
+                Pipeline,
+                FunctionTransformer,
+                str,
+            ],
             List[str],
         ]
     ] = []

--- a/src/patientflow/viz/features.py
+++ b/src/patientflow/viz/features.py
@@ -58,7 +58,7 @@ def plot_features(
     -----
     The function sorts models by prediction time and creates a horizontal bar plot
     for each model showing the top N most important features. Feature names are
-    truncated to 25 characters for better display.
+    shown in full (not truncated) so long transformer output names remain distinct.
     """
     # Convert dict to list if needed
     if isinstance(trained_models, dict):
@@ -72,7 +72,9 @@ def plot_features(
     )
 
     num_plots = len(trained_models_sorted)
-    fig, axs = plt.subplots(1, num_plots, figsize=(num_plots * 6, 12))
+    # Wider panels when a single clock is plotted (side-by-side deck slides).
+    panel_w = 8 if num_plots == 1 else 6
+    fig, axs = plt.subplots(1, num_plots, figsize=(num_plots * panel_w, 12))
 
     # Handle case of single prediction time
     if num_plots == 1:
@@ -87,8 +89,7 @@ def plot_features(
         transformed_cols = pipeline.named_steps[
             "feature_transformer"
         ].get_feature_names_out()
-        transformed_cols = [col.split("__")[-1] for col in transformed_cols]
-        truncated_cols = [col[:25] for col in transformed_cols]
+        feature_names = [col.split("__")[-1] for col in transformed_cols]
 
         # Get feature importances
         feature_importances = pipeline.named_steps["classifier"].feature_importances_
@@ -101,7 +102,7 @@ def plot_features(
         hour, minutes = prediction_time
         ax.barh(range(len(indices)), feature_importances[indices], align="center")
         ax.set_yticks(range(len(indices)))
-        ax.set_yticklabels(np.array(truncated_cols)[indices])
+        ax.set_yticklabels(np.array(feature_names)[indices])
         ax.set_xlabel("Importance")
         ax.set_ylabel("Features")
         ax.set_title(f"Feature Importances for {hour}:{minutes:02}")

--- a/src/patientflow/viz/shap.py
+++ b/src/patientflow/viz/shap.py
@@ -134,8 +134,7 @@ def plot_shap(
         transformed_cols = pipeline.named_steps[
             "feature_transformer"
         ].get_feature_names_out()
-        transformed_cols = [col.split("__")[-1] for col in transformed_cols]
-        truncated_cols = [col[:45] for col in transformed_cols]
+        feature_names = [col.split("__")[-1] for col in transformed_cols]
 
         # Transform features
         X_test = pipeline.named_steps["feature_transformer"].transform(X_test)
@@ -167,7 +166,7 @@ def plot_shap(
         shap.summary_plot(
             shap_values,
             X_test,
-            **_summary_plot_kwargs(feature_names=truncated_cols, show=False),
+            **_summary_plot_kwargs(feature_names=feature_names, show=False),
         )
 
         fig = plt.gcf()

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 from sklearn.pipeline import Pipeline
 from sklearn.compose import ColumnTransformer
-from sklearn.preprocessing import OneHotEncoder, StandardScaler
+from sklearn.preprocessing import FunctionTransformer, OneHotEncoder, StandardScaler
 from xgboost import XGBClassifier
 
 from patientflow.predict.emergency_demand import dataframe_for_classifier_predict_proba
@@ -532,6 +532,63 @@ class TestClassifiers(unittest.TestCase):
     def test_infer_feature_kind_two_string_object_is_categorical(self):
         s = pd.Series(["a", "b"] * 3, dtype="object")
         self.assertEqual(infer_feature_kind(s, "x", {}), FeatureKind.CATEGORICAL)
+
+    def test_infer_feature_kind_non_nullable_bool_is_boolean(self):
+        s = pd.Series([True, False, True], dtype=bool)
+        self.assertEqual(infer_feature_kind(s, "flag", {}), FeatureKind.BOOLEAN)
+
+    def test_infer_feature_kind_nullable_boolean_is_boolean(self):
+        s = pd.Series([True, False, pd.NA], dtype="boolean")
+        self.assertEqual(infer_feature_kind(s, "flag", {}), FeatureKind.BOOLEAN)
+
+    def test_infer_feature_kind_object_true_none_remains_categorical(self):
+        """Object True/None is not treated as boolean (callers use nullable bool)."""
+        s = pd.Series([True, False, None], dtype="object")
+        self.assertEqual(infer_feature_kind(s, "flag", {}), FeatureKind.CATEGORICAL)
+
+    def test_infer_feature_kind_float_binary_with_nan_is_numeric(self):
+        """Float 1.0/NaN flags keep the numeric path (not boolean)."""
+        s = pd.Series([1.0, np.nan, 1.0])
+        self.assertEqual(infer_feature_kind(s, "flag", {}), FeatureKind.NUMERIC_BINARY)
+
+    def test_create_column_transformer_non_nullable_bool_one_float_column(self):
+        """Plain bool becomes one float column (1.0 / 0.0), not one-hot."""
+        df = pd.DataFrame({"flag": [True, False, True, False]})
+        ct = create_column_transformer(df)
+        by_col = {cols[0]: trans for _, trans, cols in ct.transformers}
+        self.assertIsInstance(by_col["flag"], FunctionTransformer)
+        out = ct.fit_transform(df)
+        self.assertEqual(out.shape, (4, 1))
+        np.testing.assert_array_equal(out.ravel(), [1.0, 0.0, 1.0, 0.0])
+
+    def test_create_column_transformer_nullable_boolean_preserves_nan(self):
+        """Nullable boolean emits one float column with NaN for <NA>, not one-hot."""
+        df = pd.DataFrame(
+            {"flag": pd.Series([True, False, pd.NA, True], dtype="boolean")}
+        )
+        ct = create_column_transformer(df)
+        by_col = {cols[0]: trans for _, trans, cols in ct.transformers}
+        self.assertIsInstance(by_col["flag"], FunctionTransformer)
+        for _, trans, _ in ct.transformers:
+            self.assertNotIsInstance(trans, OneHotEncoder)
+        out = ct.fit_transform(df)
+        self.assertEqual(out.shape, (4, 1))
+        np.testing.assert_allclose(out.ravel()[:2], [1.0, 0.0])
+        self.assertTrue(np.isnan(out.ravel()[2]))
+        self.assertEqual(out.ravel()[3], 1.0)
+
+    def test_feature_column_transformer_boolean_default_false(self):
+        """Missing boolean columns (numpy or nullable) still default to False."""
+        fit_df = pd.DataFrame(
+            {"flag": pd.Series([True, False, pd.NA], dtype="boolean")}
+        )
+        fct = FeatureColumnTransformer()
+        fct.fit(fit_df)
+        self.assertIs(fct.column_defaults_["flag"], False)
+
+        out = fct.transform(pd.DataFrame({"other": [1, 2]}))
+        self.assertIn("flag", out.columns)
+        self.assertTrue(out["flag"].eq(False).all())
 
     def test_feature_column_transformer_timedelta_default(self):
         """Missing timedelta columns are filled with pd.Timedelta(0)."""

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -15,6 +15,7 @@ from patientflow.evaluate.handlers import (
     _classifier_diagnostics_suptitle,
     _classifier_quality_suptitle,
     _distribution_comparison_suptitle,
+    evaluate_classifier_model_diagnostics,
     evaluate_classifier_probability_quality,
     evaluate_distribution,
 )
@@ -283,6 +284,75 @@ def test_arrival_delta_suptitle_uses_eval_split():
     title = _arrival_delta_suptitle(target, "medical", eval_split="valid")
     assert title == "Arrival delta plots for medical service (validation set)"
     assert "09:30" not in title
+
+
+def test_evaluate_classifier_model_diagnostics_per_clock_features(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Multi-clock diagnostics write features.png plus features_HHMM.png."""
+    feature_calls: list[dict] = []
+
+    def _capture_features(models, *args, **kwargs):
+        n = len(models) if not isinstance(models, dict) else len(models)
+        feature_calls.append(
+            {
+                "n_models": n,
+                "file_name": kwargs.get("file_name"),
+                "suptitle": kwargs.get("suptitle"),
+            }
+        )
+
+    monkeypatch.setattr(
+        "patientflow.evaluate.handlers.plot_features", _capture_features
+    )
+    monkeypatch.setattr("patientflow.evaluate.handlers.SHAP_AVAILABLE", False)
+    monkeypatch.setattr("patientflow.evaluate.handlers.plot_shap", None)
+
+    visits = pd.DataFrame({"is_admitted": [0, 1]})
+    target = EvaluationTarget(
+        flow_name="ed_admissions_cls",
+        flow_type="admissions",
+        evaluation_mode="classifier_model_diagnostics",
+        component="classifier_model_diagnostics",
+        observation_mode="admitted_at_some_point",
+    )
+    inputs = (
+        EvaluationInputsBuilder(
+            flow_selection=FlowSelection.emergency_only(),
+            prediction_dict=_uniform_prediction_dict([(6, 0), (15, 30)]),
+            eval_split="valid",
+        )
+        .add_classifier(
+            target.flow_name,
+            [
+                _minimal_trained_classifier((6, 0)),
+                _minimal_trained_classifier((15, 30)),
+            ],
+            visits,
+            "is_admitted",
+        )
+        .with_evaluation_targets([target])
+        .build()
+    )
+    collector = ScalarsCollector()
+    evaluate_classifier_model_diagnostics(
+        inputs,
+        target,
+        classifiers_dir=tmp_path / "classifiers",
+        collector=collector,
+    )
+
+    assert [c["file_name"] for c in feature_calls] == [
+        "features.png",
+        "features_0600.png",
+        "features_1530.png",
+    ]
+    assert feature_calls[0]["n_models"] == 2
+    assert feature_calls[1]["n_models"] == 1
+    assert feature_calls[2]["n_models"] == 1
+    assert "at 06:00" in feature_calls[1]["suptitle"]
+    assert "at 15:30" in feature_calls[2]["suptitle"]
+    assert len(collector.as_list()) == 2
 
 
 # --- classifier MADCAP groupings ---


### PR DESCRIPTION
## Summary
- Route pandas nullable `boolean` columns through the boolean transformer (True→1.0, False→0.0, `<NA>`→NaN) instead of one-hot encoding, so missing flags are not treated as a third category.
- Write per-clock `features_HHMM.png` alongside the multi-clock `features.png` strip, and show full feature names on both feature-importance and SHAP plots.

## Test plan
- [x] Classifier tests: nullable boolean stays `FeatureKind.BOOLEAN`; object `True`/`None` stays categorical; transformer output is one float column with NaN for `<NA>`
- [x] Eval diagnostics: two prediction times produce `features.png`, `features_0600.png`, and `features_1530.png`